### PR TITLE
Reopen LinkView in an initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ $ ember serve
 ```
 
 ## Installation
+
+Using ember-cli 0.1.5:
+```sh
+$ ember install:addon ember-cli-materialize
+```
+
+Using previous versions:
 ```sh
 # install via npm
 $ npm install ember-cli-materialize --save-dev

--- a/addon/initializers/link-view.js
+++ b/addon/initializers/link-view.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export function initialize(/* container, application */) {
+  Ember.LinkView.reopen({
+    attributeBindings: ['data-activates'],
+  });
+}
+
+export default {
+  name: 'link-view',
+  initialize: initialize
+};

--- a/app/initializers/link-view.js
+++ b/app/initializers/link-view.js
@@ -1,0 +1,6 @@
+import { initialize } from 'ember-cli-materialize/initializers/link-view';
+
+export default {
+  name: 'link-view',
+  initialize: initialize
+};

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -11,10 +11,6 @@ var App = Ember.Application.extend({
   Resolver: Resolver
 });
 
-Ember.LinkView.reopen({
-  attributeBindings: ['data-activates'],
-});
-
 loadInitializers(App, config.modulePrefix);
 
 export default App;

--- a/tests/unit/initializers/link-view-test.js
+++ b/tests/unit/initializers/link-view-test.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import { initialize } from 'ember-cli-materialize/initializers/link-view';
+
+var container, application;
+
+module('LinkViewInitializer', {
+  setup: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      container = application.__container__;
+      application.deferReadiness();
+    });
+  }
+});
+
+test('"data-activates" is added to attributeBindings', function() {
+  initialize(container, application);
+
+  var linkView = Ember.LinkView.create();
+  ok(linkView.attributeBindings.indexOf('data-activates')!==-1,
+    "'data-activates' must be present in `attributeBindings`");
+});


### PR DESCRIPTION
Spent some time figuring out why my navbar wasn't working. "data-activates" attribute must be bound in LinkView.

The test isn't running in PhantomJS, but it is passing in Chrome. :/

Followed this method: http://pixelhandler.com/posts/develop-embercomponents-for-sharing-as-ember-cli-addons-a-practical-example#whataboutinitializers