### PR TITLE
Removed extra semi-colon

### DIFF
--- a/blueprints/ember-cli-materialize/files/config/environment.js
+++ b/blueprints/ember-cli-materialize/files/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
     },
     sassOptions: {
       includePaths: ['bower_components/materialize/sass']
-    },
+    }
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
The environment.js blueprint contained an extra semi-colon following the sassOptions block.