### PR TITLE
Create component for form input

### DIFF
--- a/addon/components/materialize-input.js
+++ b/addon/components/materialize-input.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import layout from '../templates/components/materialize-input';
+
+export default Ember.Component.extend({
+  init: function() {
+    this._super();
+    // bind validation errors
+    var propertyPath = this.get('valueBinding._label');
+    if (Ember.isPresent(propertyPath)) {
+      Ember.Binding.from('targetObject.errors.' + propertyPath)
+        .to('errors')
+        .connect(this);
+    }
+  },
+  layout: layout,
+  tagName: 'div',
+  classNames: ['input-field'],
+  validate: false,
+  id: Ember.computed(function() {
+    var elementId = this.get('elementId');
+    return elementId + '-input';
+  }),
+  didInsertElement: function() {
+    // make sure the label moves when a value is bound.
+    var labelSelector = this.$('>label');
+    if (Ember.isPresent(this.get('value')) && !labelSelector.hasClass('active')) {
+      labelSelector.addClass('active');
+      labelSelector.trigger('validate');
+    }
+    // add icon prefix if necessary
+    var icon = this.get('icon');
+    var iconSelector = this.$('>i');
+    if (Ember.isPresent(icon)) {
+      iconSelector.addClass(icon);
+      iconSelector.addClass('prefix');
+    }
+  }
+});
+

--- a/addon/components/materialize-input.js
+++ b/addon/components/materialize-input.js
@@ -27,13 +27,6 @@ export default Ember.Component.extend({
       labelSelector.addClass('active');
       labelSelector.trigger('validate');
     }
-    // add icon prefix if necessary
-    var icon = this.get('icon');
-    var iconSelector = this.$('>i');
-    if (Ember.isPresent(icon)) {
-      iconSelector.addClass(icon);
-      iconSelector.addClass('prefix');
-    }
   }
 });
 

--- a/addon/templates/components/materialize-input.hbs
+++ b/addon/templates/components/materialize-input.hbs
@@ -1,0 +1,9 @@
+{{#if icon}}<i></i>{{/if}}
+{{input id=id value=value classNameBindings="validate:validate: errors:invalid:valid" type="text"
+        required=required pattern=pattern maxlength=maxlength readonly=readonly disabled=disabled
+        autocomplete=autocomplete}}
+<label {{bind-attr for=id}}>{{label}}</label>
+<small class="red-text">
+  {{#if errors}} {{errors.firstObject}} {{else}} &nbsp; {{/if}}
+</small>
+

--- a/addon/templates/components/materialize-input.hbs
+++ b/addon/templates/components/materialize-input.hbs
@@ -1,4 +1,6 @@
-{{#if icon}}<i></i>{{/if}}
+{{#if icon}}
+    <i {{bind-attr class="icon :prefix"}}></i>
+{{/if}}
 {{input id=id value=value classNameBindings="validate:validate: errors:invalid:valid" type="text"
         required=required pattern=pattern maxlength=maxlength readonly=readonly disabled=disabled
         autocomplete=autocomplete}}

--- a/app/components/materialize-input.js
+++ b/app/components/materialize-input.js
@@ -1,0 +1,3 @@
+import materializeInput from 'ember-cli-materialize/components/materialize-input';
+
+export default materializeInput;

--- a/tests/dummy/app/controllers/input.js
+++ b/tests/dummy/app/controllers/input.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.ObjectController.extend({
+
+  nameDidChange: function() {
+    var errors = { name: [] };
+    if (!Ember.isPresent(this.get('name'))) {
+      errors.name = ['This field is required'];
+    } else {
+      errors.name = [];
+    }
+    this.set('errors', errors);
+  }.observes('name')
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route("navbar");
   this.route("cards");
   this.route("collapsible");
+  this.route("input");
 });
 
 export default Router;

--- a/tests/dummy/app/routes/input.js
+++ b/tests/dummy/app/routes/input.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model: function() {
+    return Ember.Object.create({ name: null });
+  },
+
+  setupController: function(controller, model) {
+    this._super(controller, model);
+    controller.set('errors', { name: ['This field is required'] });
+  }
+
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,6 +3,7 @@
   <li>{{#link-to 'navbar'}}Navbar{{/link-to}}</li>
   <li>{{#link-to 'cards'}}Cards{{/link-to}}</li>
   <li>{{#link-to 'collapsible'}}Collapsible{{/link-to}}</li>
+  <li>{{#link-to 'input'}}Input{{/link-to}}</li>
 {{/materialize-navbar}}
 
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -34,6 +34,7 @@
       {{#link-to 'navbar' class="collection-item"}}Navbar<span class="new badge">1</span>{{/link-to}}
       {{#link-to 'cards' class="collection-item"}}Cards<span class="new badge">1</span>{{/link-to}}
       {{#link-to 'collapsible' class="collection-item"}}Collapsible<span class="new badge">1</span>{{/link-to}}
+      {{#link-to 'input' class="collection-item"}}Input<span class="new badge">1</span>{{/link-to}}
     </ul>
   </div>
 

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -1,0 +1,87 @@
+<div class="section index-banner">
+    <div class="container">
+        <div class="row">
+            <div class="col s12 m9">
+                <h1 class="header">Input</h1>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class='container'>
+    <div class="section">
+        <div class="intro">
+            <h4 class="col s12 header">The component supports the following options:</h4>
+            <ul>
+                <li>label, default value <span class="default-value badge">null</span></li>
+                <li>icon, default value <span class="default-value badge">null</span></li>
+                <li>value, default value <span class="default-value badge">null</span></li>
+                <li>required, default value <span class="default-value badge">false</span></li>
+                <li>readonly, default value <span class="default-value badge">false</span></li>
+                <li>disabled, default value <span class="default-value badge">false</span></li>
+                <li>maxlength, default value <span class="default-value badge">null</span></li>
+                <li>pattern, default value <span class="default-value badge">null</span></li>
+                <li>validate, default value <span class="default-value badge">false</span></li>
+                <li>autocomplete, default value <span class="default-value badge">null</span></li>
+            </ul>
+        </div>
+    </div>
+    <div class="section">
+        <h4 class="col s12 header">Input</h4>
+        <div class="button-example">
+            <br/>
+            {{materialize-input value="Hi Mom" label='Example'}}
+
+            <pre class=" language-markup">
+<code class=" col s12 language-markup">
+    <span>&#123;&#123;</span>materialize-input value="Hi Mom" label="Example"<span>&#125;&#125;</span>
+</code>
+      </pre>
+        </div>
+    </div>
+
+    <div class="section">
+        <h4 class="col s12 header">Input with Icon</h4>
+        <div class="button-example">
+            <br/>
+          {{materialize-input value="Hi Mom" label='Example' icon="mdi-action-face-unlock"}}
+
+            <pre class=" language-markup">
+<code class=" col s12 language-markup">
+    <span>&#123;&#123;</span>materialize-input value="Hi Mom" label="Example" icon="mdi-action-face-unlock"<span>&#125;&#125;</span>
+</code>
+      </pre>
+        </div>
+    </div>
+
+
+    <div class="section">
+        <h4 class="col s12 header">Validations</h4>
+      <p>
+          Validations can be performed using HTML5 browser validation by passing validate=true to the component
+          or you can take advantage of the ember-validations addon w/out additional configuration of the component.
+          The following example simulates ember-validations style validation using an observer on the controller's name
+          property.
+      </p>
+        <div class="button-example">
+            <br/>
+            {{materialize-input value=name label='Name'}}
+
+<pre class=" language-markup">
+<code class=" col s12 language-markup">
+<span>&#123;&#123;</span>materialize-input value=name label="Name"<span>&#125;&#125;</span>
+
+// controller example
+nameDidChange: function() {
+  if (!Ember.isPresent(this.get('name'))) {
+    this.set('errors', { name: ['This field is required'] });
+  } else {
+    this.set('errors', { name: [] });
+  }
+}.observes('name')
+</code>
+</pre>
+        </div>
+    </div>
+</div>
+

--- a/tests/unit/components/materialize-input-test.js
+++ b/tests/unit/components/materialize-input-test.js
@@ -1,0 +1,55 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('materialize-input', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+
+test('has class input-field', function(assert) {
+  var component = this.subject();
+  this.render();
+  assert.ok(component.$().hasClass('input-field'));
+});
+
+test('has a label', function(assert) {
+  var label = 'My Input';
+  var component = this.subject({ label: label });
+  this.render();
+  assert.equal(component.$('>label').text(), label);
+});
+
+test('has a value', function(assert) {
+  var value = 'My Input Value';
+  var component = this.subject({ value: value });
+  this.render();
+  assert.equal(component.$('>input').val(), value);
+});
+
+test('label is active with value', function(assert) {
+  var component = this.subject({ value: 'some text' });
+  this.render();
+  assert.ok(component.$('>label').hasClass('active'));
+});
+
+test('has an icon', function(assert) {
+  var icon = 'mdi-action-face-unlock';
+  var component = this.subject({ icon: icon });
+  this.render();
+  assert.ok(component.$('>i').hasClass(icon));
+});


### PR DESCRIPTION
This PR includes an input component that supports ember-validation style validation messages (error object on the model/controller) as well as html5 browser validation.  The component addresses an issue where the label does not move out of the input element when bound to a value as mentioned in an issue on the materializecss repo.  Icon prefix is also supported.

As the textarea component I have in mind has some similarities, I'll likely wait to see if this is merged to combine the commonalities.  Until i know whether this will be merged or not, I'll create a branch to work on the date input component so a separate PR can be created from there.  