### PR TITLE
Fix dummy app CSS path

### DIFF
--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -10,7 +10,7 @@
     {{content-for 'head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/ember-cli-materialize.css">
+    <link rel="stylesheet" href="assets/dummy.css">
 
     {{content-for 'head-footer'}}
   </head>


### PR DESCRIPTION
Currently the dummy app is looking for an `assets/ember-cli-materialize.css` file, which doesn't exist. I have changed the dummy app's index.html to look for `dummy.css`, which results in everything being rendered with the materialize css as expected.