### PR TITLE
Tabs 

### DIFF
--- a/addon/components/materialize-tabs-tab.js
+++ b/addon/components/materialize-tabs-tab.js
@@ -4,10 +4,15 @@ import layout from '../templates/components/materialize-tabs-tab';
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'li',
-  classNames: ['materialize-tabs-tab', 'tab'],
-  init: function () {
-    this._super(...arguments);
-  },
+  classNames: ['materialize-tabs-tab', 'tab', 'col'],
+  classNameBindings: ['_colClass'],
+
+  colWidth: Ember.computed.alias('_tabSet.colWidth'),
+
+  _colClass: Ember.computed('colWidth', function () {
+    return 's' + this.get('colWidth');
+  }),
+
   _tabSet: Ember.computed(function () {
     return this.nearestWithProperty('___materializeTabs');
   }),

--- a/addon/components/materialize-tabs-tab.js
+++ b/addon/components/materialize-tabs-tab.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import layout from '../templates/components/materialize-tabs-tab';
+
+export default Ember.Component.extend({
+  layout: layout,
+  tagName: 'li',
+  classNames: ['materialize-tabs-tab', 'tab'],
+
+  _tabSet: Ember.computed(function () {
+    return this.nearestWithProperty('___materializeTabs');
+  }),
+
+  _active: Ember.computed('_tabSet.selected', 'value', function () {
+    return this.get('_tabSet.selected') === this.get('value');
+  }),
+
+  click: function () {
+    this.trigger('tabClicked', this);
+  },
+
+  didInsertElement: function () {
+    this._super(...arguments);
+    var tabSet = this.get('_tabSet');
+    if (!tabSet) {
+      throw new Error('materialize-tabs-tab cannot be used outside the context of a materialize-tabs');
+    }
+    tabSet.registerTab(this);
+  }
+});

--- a/addon/components/materialize-tabs-tab.js
+++ b/addon/components/materialize-tabs-tab.js
@@ -5,7 +5,9 @@ export default Ember.Component.extend({
   layout: layout,
   tagName: 'li',
   classNames: ['materialize-tabs-tab', 'tab'],
-
+  init: function () {
+    this._super(...arguments);
+  },
   _tabSet: Ember.computed(function () {
     return this.nearestWithProperty('___materializeTabs');
   }),

--- a/addon/components/materialize-tabs.js
+++ b/addon/components/materialize-tabs.js
@@ -4,15 +4,15 @@ var map = Ember.EnumerableUtils.map;
 
 export default Ember.Component.extend({
   layout: layout,
-  tagName: 'ul',
   content: null,
-  classNames: ['materialize-tabs', 'tabs'],
+  classNames: ['materialize-tabs', 'row'],
   ___materializeTabs: true,
   _tabComponents: null,
   numTabs: Ember.computed.alias('_tabComponents.length'),
   selected: null,
   optionValuePath: 'id',
   optionLabelPath: 'title',
+  colWidth: 2,
 
   init: function () {
     this._super(...arguments);
@@ -57,8 +57,6 @@ export default Ember.Component.extend({
       this._updateIndicatorPosition();
     });
   },
-
-  _indicatorUpdater: null,
 
   _setActiveTab: function (tabComponent) {
     this.set('selected', tabComponent.get('value'));

--- a/addon/components/materialize-tabs.js
+++ b/addon/components/materialize-tabs.js
@@ -1,14 +1,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/materialize-tabs';
+var map = Ember.EnumerableUtils.map;
 
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'ul',
+  content: null,
   classNames: ['materialize-tabs', 'tabs'],
   ___materializeTabs: true,
   _tabComponents: null,
   numTabs: Ember.computed.alias('_tabComponents.length'),
   selected: null,
+  optionValuePath: 'id',
+  optionLabelPath: 'title',
 
   init: function () {
     this._super(...arguments);
@@ -36,17 +40,28 @@ export default Ember.Component.extend({
     }
   },
 
+  _content: Ember.computed('content.[]', 'optionLabelPath', 'optionValuePath', function () {
+    var lp = this.get('optionLabelPath');
+    var vp = this.get('optionValuePath');
+    return new Ember.A(map(this.get('content') || [], c => ({id: c[vp], title: c[lp]})));
+  }),
+
   didInsertElement: function () {
     this._super(...arguments);
-    if (this.get('selected') === null && this.get('content.length') > 0) {
-      this.set('selected', this.get('content')[0].id);
+    var tabComponents = this.get('_tabComponents');
+    if (this.get('selected') === null && tabComponents.length > 0) {
+      this.set('selected', tabComponents[tabComponents.length - 1].get('value'));
     }
     this._updateIndicatorPosition(false);
+    this.addObserver('selected', function () {
+      this._updateIndicatorPosition();
+    });
   },
+
+  _indicatorUpdater: null,
 
   _setActiveTab: function (tabComponent) {
     this.set('selected', tabComponent.get('value'));
-    this._updateIndicatorPosition();
   },
 
   registerTab: function (tabComponent) {

--- a/addon/components/materialize-tabs.js
+++ b/addon/components/materialize-tabs.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+import layout from '../templates/components/materialize-tabs';
+
+export default Ember.Component.extend({
+  layout: layout,
+  tagName: 'ul',
+  classNames: ['materialize-tabs', 'tabs'],
+  ___materializeTabs: true,
+  _tabComponents: null,
+  numTabs: Ember.computed.alias('_tabComponents.length'),
+  selected: null,
+
+  init: function () {
+    this._super(...arguments);
+    this.set('_tabComponents', new Ember.A([]));
+  },
+
+  _updateIndicatorPosition: function (animate=true) {
+    var tabComponent = this.get('_tabComponents').filterBy('value', this.get('selected'))[0];
+    var tabSetRect = this.element.getBoundingClientRect();
+    if (tabComponent) {
+      var tabRect = tabComponent.element.getBoundingClientRect();
+
+      var cssParams = {
+        left: tabRect.left - tabSetRect.left,
+        right: tabSetRect.right - tabRect.right
+      };
+
+      if (!animate) {
+        this.$('.indicator').css(cssParams);
+      }
+      else {
+        this.$('.indicator1').velocity(cssParams, {duration: 150});
+        this.$('.indicator2').velocity(cssParams, {duration: 150, delay: 40});
+      }
+    }
+  },
+
+  didInsertElement: function () {
+    this._super(...arguments);
+    if (this.get('selected') === null && this.get('content.length') > 0) {
+      this.set('selected', this.get('content')[0].id);
+    }
+    this._updateIndicatorPosition(false);
+  },
+
+  _setActiveTab: function (tabComponent) {
+    this.set('selected', tabComponent.get('value'));
+    this._updateIndicatorPosition();
+  },
+
+  registerTab: function (tabComponent) {
+    this.get('_tabComponents').addObject(tabComponent);
+    tabComponent.on('tabClicked', function (tab) {
+      this._setActiveTab(tab);
+    }.bind(this));
+  }
+});

--- a/addon/templates/components/materialize-tabs-tab.hbs
+++ b/addon/templates/components/materialize-tabs-tab.hbs
@@ -1,0 +1,3 @@
+<a {{bind-attr class="_active:active"}}>
+{{title}}
+</a>

--- a/addon/templates/components/materialize-tabs.hbs
+++ b/addon/templates/components/materialize-tabs.hbs
@@ -1,5 +1,6 @@
-{{#each content as |tab|}}
+{{#each tab in _content}}
   {{materialize-tabs-tab title=tab.title value=tab.id}}
 {{/each}}
+{{yield}}
 <div class="indicator indicator1"></div>
 <div class="indicator indicator2"></div>

--- a/addon/templates/components/materialize-tabs.hbs
+++ b/addon/templates/components/materialize-tabs.hbs
@@ -1,0 +1,5 @@
+{{#each content as |tab|}}
+  {{materialize-tabs-tab title=tab.title value=tab.id}}
+{{/each}}
+<div class="indicator indicator1"></div>
+<div class="indicator indicator2"></div>

--- a/addon/templates/components/materialize-tabs.hbs
+++ b/addon/templates/components/materialize-tabs.hbs
@@ -1,6 +1,10 @@
-{{#each tab in _content}}
-  {{materialize-tabs-tab title=tab.title value=tab.id}}
-{{/each}}
-{{yield}}
-<div class="indicator indicator1"></div>
-<div class="indicator indicator2"></div>
+<div class="col s12">
+  <ul class="tabs">
+    {{#each tab in _content}}
+      {{materialize-tabs-tab title=tab.title value=tab.id}}
+    {{/each}}
+    {{yield}}
+    <div class="indicator indicator1"></div>
+    <div class="indicator indicator2"></div>
+  </ul>
+</div>

--- a/app/components/materialize-tabs-tab.js
+++ b/app/components/materialize-tabs-tab.js
@@ -1,0 +1,3 @@
+import materializeTabsTab from 'ember-cli-materialize/components/materialize-tabs-tab';
+
+export default materializeTabsTab;

--- a/app/components/materialize-tabs.js
+++ b/app/components/materialize-tabs.js
@@ -1,0 +1,3 @@
+import materializeTabs from 'ember-cli-materialize/components/materialize-tabs';
+
+export default materializeTabs;

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "ember-cli-qunit": "0.3.9",
     "ember-cli-sass": "^3.2.2",
     "ember-cli-uglify": "1.0.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.3"
+    "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.3",
+    "liquid-fire": "git+ssh://git@github.com:ef4/liquid-fire.git#master"
   },
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.3",
-    "liquid-fire": "git+ssh://git@github.com:ef4/liquid-fire.git#master"
+    "liquid-fire": "git+ssh://git@github.com:ef4/liquid-fire.git#8fcefd057478ab6852d7b8b3fc8526aa5079553c"
   },
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
   "keywords": [

--- a/tests/dummy/app/controllers/tabs.js
+++ b/tests/dummy/app/controllers/tabs.js
@@ -6,8 +6,13 @@ export default Ember.Controller.extend({
     {id: 'b', title: 'Second'},
     {id: 'c', title: 'Third'}
   ]),
+  alternateTabsContent: new Ember.A([
+    {key: 'a', label: 'First'},
+    {key: 'b', label: 'Second'},
+    {key: 'c', label: 'Third'}
+  ]),
   basicTabsSelection: 'a',
-
+  secondTabsSelection: 'g',
   actions: {
     addTab: function () {
       this.get('basicTabsContent').addObject({id: 'd', title: 'Fourth'});

--- a/tests/dummy/app/controllers/tabs.js
+++ b/tests/dummy/app/controllers/tabs.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  basicTabsContent: new Ember.A([
+    {id: 'a', title: 'First'},
+    {id: 'b', title: 'Second'},
+    {id: 'c', title: 'Third'}
+  ]),
+  basicTabsSelection: 'a',
+
+  actions: {
+    addTab: function () {
+      this.get('basicTabsContent').addObject({id: 'd', title: 'Fourth'});
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,12 +8,13 @@ var Router = Ember.Router.extend({
 Router.map(function() {
   this.route("badges");
   this.route("buttons");
-  this.route("navbar");
   this.route("cards");
   this.route("collapsible");
   this.route("input");
   this.route("loader");
+  this.route("navbar");
   this.route("parallax");
+  this.route("tabs");
 });
 
 export default Router;

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -64,6 +64,10 @@
       {{#link-to 'parallax' class="collection-item"}}
         Parallax{{#materialize-badge class="new"}}1{{/materialize-badge}}
       {{/link-to}}
+
+      {{#link-to 'tabs' class="collection-item"}}
+        Tabs{{#materialize-badge class="new"}}1{{/materialize-badge}}
+      {{/link-to}}
     </ul>
   </div>
 

--- a/tests/dummy/app/templates/tabs.hbs
+++ b/tests/dummy/app/templates/tabs.hbs
@@ -1,0 +1,35 @@
+<div class="section index-banner">
+  <div class="container">
+    <div class="row">
+      <div class="col s12 m9">
+        <h1 class="header">Tabs</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class='container'>
+  <div class="section">
+    <div class="intro">
+      <h4 class="col s12 header">The component supports one option:</h4>
+      <ul>
+        <li>mode, default value <span class="default-value badge">indeterminate</span> - Loader mode (determinate, indeterminate, circular)</li>
+
+      </ul>
+    </div>
+  </div>
+
+  <!-- INDETERMINATE LOADER -->
+  <div class="section">
+    <h4 class="col s12 header">Simple Tabs</h4>
+    <div class="tabs-example basic-tabs-example">
+      {{materialize-tabs
+        content=basicTabsContent
+        selected=basicTabsSelection}}
+
+
+    </div>
+  </div>
+
+
+</div>

--- a/tests/dummy/app/templates/tabs.hbs
+++ b/tests/dummy/app/templates/tabs.hbs
@@ -11,7 +11,7 @@
 <div class='container'>
   <div class="section">
     <div class="intro">
-      <h4 class="col s12 header">The component supports one option:</h4>
+      <h4 class="col s12 header">The component supports several options:</h4>
       <ul>
         <li>mode, default value <span class="default-value badge">indeterminate</span> - Loader mode (determinate, indeterminate, circular)</li>
 
@@ -26,9 +26,22 @@
       {{materialize-tabs
         content=basicTabsContent
         selected=basicTabsSelection}}
-
-
     </div>
+    <div class="tabs-example second-tabs-example">
+    {{materialize-tabs
+        content=alternateTabsContent
+        selected=basicTabsSelection
+        optionValuePath='key'
+        optionLabelPath='label'}}
+    </div>
+    <div class="tabs-example third-tabs-example">
+        {{#materialize-tabs
+          selected=basicTabsSelection}}
+          {{materialize-tabs-tab value='a' title="Sixth"}}
+          {{materialize-tabs-tab value='b' title="Seventh"}}
+          {{materialize-tabs-tab value='c' title="Eigth"}}
+        {{/materialize-tabs}}
+      </div>
   </div>
 
 

--- a/tests/dummy/app/templates/tabs.hbs
+++ b/tests/dummy/app/templates/tabs.hbs
@@ -13,35 +13,76 @@
     <div class="intro">
       <h4 class="col s12 header">The component supports several options:</h4>
       <ul>
-        <li>mode, default value <span class="default-value badge">indeterminate</span> - Loader mode (determinate, indeterminate, circular)</li>
-
+        <li>content, default value <span class="default-value badge">[]</span> -  tabs array</li>
+        <li>selected, default value <span class="default-value badge">null</span> -  selected tab id</li>
+        <li>colWidth, default value <span class="default-value badge">2</span> -  width of tabs, in grid columns</li>
       </ul>
     </div>
   </div>
 
-  <!-- INDETERMINATE LOADER -->
   <div class="section">
-    <h4 class="col s12 header">Simple Tabs</h4>
-    <div class="tabs-example basic-tabs-example">
+    <h4 class="col s12 header">Basic Usage</h4>
+    <p>Creating a basic set of tabs is simple, and you have several syntax options to choose from.
+    First, you can pass an array of tabs to the <code>&#123;&#123;materialize-tabs&#125;&#125;</code> component:</p>
+    <div class="tabs-example basic-tabs-example z-depth-1">
       {{materialize-tabs
         content=basicTabsContent
         selected=basicTabsSelection}}
     </div>
-    <div class="tabs-example second-tabs-example">
+
+    <pre class=" language-markup">
+      <code class=" col s8 language-markup">
+  <span>&#123;&#123;</span>materialize-tabs
+      content=tabSet
+      selected=selectedTabId<span>&#125;&#125;</span>
+      </code>
+    </pre>
+    <p>By default, the structure of the array of tabs is expected to look like this</p>
+
+    <pre class=" language-markup">
+    <code class=" col s8 language-markup">
+    [ {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'} ]
+    </code>
+    </pre>
+    <p>If you wish to use different key and value properties, you may specify some additional options</p>
+       <div class="tabs-example second-tabs-example z-depth-1">
+
     {{materialize-tabs
         content=alternateTabsContent
         selected=basicTabsSelection
         optionValuePath='key'
         optionLabelPath='label'}}
-    </div>
-    <div class="tabs-example third-tabs-example">
+        </div>
+    <pre class=" language-markup">
+      <code class=" col s8 language-markup">
+  <span>&#123;&#123;</span>materialize-tabs
+      content=tabSet
+      selected=selectedTabId
+      optionValuePath='key'
+      optionLabelPath='label'<span>&#125;&#125;</span>
+      </code>
+    </pre>
+    <h4 class="col s12 header">Alternate Syntax</h4>
+    <p>The following syntax allows for more granular control over the particulars of each tab</p>
+    <div class="tabs-example third-tabs-example z-depth-1">
         {{#materialize-tabs
           selected=basicTabsSelection}}
           {{materialize-tabs-tab value='a' title="Sixth"}}
           {{materialize-tabs-tab value='b' title="Seventh"}}
-          {{materialize-tabs-tab value='c' title="Eigth"}}
+          {{materialize-tabs-tab value='c' title="Eighth"}}
         {{/materialize-tabs}}
-      </div>
+    </div>
+    <pre class=" language-markup">
+      <code class=" col s8 language-markup">
+  <span>&#123;&#123;</span>#materialize-tabs selected=selectedTabId<span>&#125;&#125;</span>
+      <span>&#123;&#123;</span>materialize-tabs-tab value='a' title='Sixth'<span>&#125;&#125;</span>
+      <span>&#123;&#123;</span>materialize-tabs-tab value='b' title='Seventh'<span>&#125;&#125;</span>
+      <span>&#123;&#123;</span>materialize-tabs-tab value='c' title='Eighth'<span>&#125;&#125;</span>
+  <span>&#123;&#123;</span>/materialize-tabs<span>&#125;&#125;</span>
+      </code>
+    </pre>
   </div>
 
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,7 +11,7 @@
     {{content-for 'test-head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <!-- <link rel="stylesheet" href="assets/dummy.css"> -->
     <link rel="stylesheet" href="assets/test-support.css">
 
     {{content-for 'head-footer'}}

--- a/tests/integration/tabs-test.js
+++ b/tests/integration/tabs-test.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+import startApp from '../../tests/helpers/start-app';
+import { test } from 'ember-qunit';
+
+var App;
+
+module('Tabs - Integration', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+
+test('Basic Example - One set of tabs should be rendered, with three tabs', function(assert) {
+  visit('/tabs').then(function() {
+    assert.equal(find('.basic-tabs-example .materialize-tabs').length, 1, 'One set of tabs');
+    assert.equal(find('.basic-tabs-example .materialize-tabs .materialize-tabs-tab a').length, 3, 'Three tabs in the set');
+    assert.equal(find('.basic-tabs-example .materialize-tabs .materialize-tabs-tab:first-child a').text().trim(), 'First', 'Label of first tab is "First"');
+    assert.equal(find('.basic-tabs-example .materialize-tabs .materialize-tabs-tab:nth-child(2) a').text().trim(), 'Second', 'Label of second tab is "Second"');
+    assert.equal(find('.basic-tabs-example .materialize-tabs .materialize-tabs-tab:nth-child(3) a').text().trim(), 'Third', 'Label of third tab is "Third"');
+
+    assert.equal(find('.basic-tabs-example .materialize-tabs .materialize-tabs-tab:first-child .active').length, 1, 'First tab is initially selected');
+
+
+  });
+});

--- a/tests/unit/components/materialize-tabs-tab-test.js
+++ b/tests/unit/components/materialize-tabs-tab-test.js
@@ -1,0 +1,4 @@
+/**
+ * Testing of this component is included in the materialize-tabs test cases, since this component
+ * cannot exist independently
+ */

--- a/tests/unit/components/materialize-tabs-test.js
+++ b/tests/unit/components/materialize-tabs-test.js
@@ -1,0 +1,121 @@
+import Ember from 'ember';
+
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('materialize-tabs', {
+  // Specify the other units that are required for this test
+  needs: ['component:materialize-tabs-tab']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+
+  component.setProperties({
+    content: new Ember.A([
+      {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'}
+    ]),
+    selected: 'a'
+  });
+
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('programatically setting selected tab', function (assert) {
+
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+
+  component.setProperties({
+    content: new Ember.A([
+      {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'}
+    ]),
+    selected: 'a'
+  });
+  this.render();
+  assert.equal(component.$('.active').text().trim(), 'First', 'First tab is initially selected');
+
+  Ember.run.next(function () {
+    component.set('selected', 'b');
+    Ember.run.next(function () {
+      assert.equal(component.$('.active').text().trim(), 'Second', 'Second tab is now selected');
+    });
+  });
+});
+
+test('programatically adding tabs', function (assert) {
+
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+
+  component.setProperties({
+    content: new Ember.A([
+      {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'}
+    ]),
+    selected: 'a'
+  });
+  this.render();
+
+  assert.equal(Ember.$('.materialize-tabs-tab').length, 3, 'Three tabs initially');
+
+
+  Ember.run.next(this, function () {
+
+    component.get('content').addObject({id: 'd', title: 'Fourth'});
+    Ember.run.schedule('afterRender', function () {
+      assert.equal(Ember.$('.materialize-tabs-tab').length, 4, 'Four tabs now');
+    });
+  });
+});
+
+test('No initial selection - first tab should be selected', function (assert) {
+
+  assert.expect(1);
+
+  // Creates the component instance
+  var component = this.subject();
+
+  component.setProperties({
+    content: new Ember.A([
+      {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'}
+    ])
+  });
+  this.render();
+  assert.equal(component.$('.active').text().trim(), 'First', 'First tab is initially selected');
+});
+
+
+test('Empty content - should render an empty UL', function (assert) {
+
+  assert.expect(1);
+
+  // Creates the component instance
+  var component = this.subject();
+
+  component.setProperties({
+    content: new Ember.A([])
+  });
+  this.render();
+  assert.equal(component.$('.materialize-tabs-tab').length, 0, 'No tabs should be rendered');
+});

--- a/tests/unit/components/materialize-tabs-test.js
+++ b/tests/unit/components/materialize-tabs-test.js
@@ -119,3 +119,24 @@ test('Empty content - should render an empty UL', function (assert) {
   this.render();
   assert.equal(component.$('.materialize-tabs-tab').length, 0, 'No tabs should be rendered');
 });
+
+
+test('Col width - should result in the correct CSS classes', function (assert) {
+
+  assert.expect(3);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component.get('colWidth'), 2, 'Default col width is 2');
+  component.setProperties({
+    colWidth: 4,
+    content: new Ember.A([
+      {id: 'a', title: 'First'},
+      {id: 'b', title: 'Second'},
+      {id: 'c', title: 'Third'}
+    ])
+  });
+  this.render();
+  assert.equal(component.get('_tabComponents')[0].get('colWidth'), 4, 'Col width on tab set applies to tabs');
+  assert.equal(component.get('_tabComponents')[0].get('_colClass'), 's4', 'tab col class is correct');
+});

--- a/tests/unit/components/materialize-tabs-test.js
+++ b/tests/unit/components/materialize-tabs-test.js
@@ -52,7 +52,7 @@ test('programatically setting selected tab', function (assert) {
 
   Ember.run.next(function () {
     component.set('selected', 'b');
-    Ember.run.next(function () {
+    Ember.run.schedule('afterRender', function () {
       assert.equal(component.$('.active').text().trim(), 'Second', 'Second tab is now selected');
     });
   });


### PR DESCRIPTION
A basic tabs component. I have removed the routable component, and will propose that as another distinct component extending from this one.


```handlebars
{{materialize-tabs
        content=alternateTabsContent
        selected=basicTabsSelection
        optionValuePath='key'
        optionLabelPath='label'}}
```
OR

```handlebars
{{#materialize-tabs
    selected=basicTabsSelection}}
    {{materialize-tabs-tab value='a' title="Sixth"}}
    {{materialize-tabs-tab value='b' title="Seventh"}}
    {{materialize-tabs-tab value='c' title="Eighth"}}
{{/materialize-tabs}}
```
I have opted to implement the animation using velocity, in an effort to make this as idiomatic as possible, and have left the `$.material_tabs()` script unused.

