### PR TITLE
Restore ember-1.10 compatibility, and add ember-try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try:testall

--- a/addon/templates/components/materialize-loader.hbs
+++ b/addon/templates/components/materialize-loader.hbs
@@ -1,8 +1,8 @@
 {{#if isBarType}}
-  <div class={{barClassName}} style={{barStyle}}></div>
+  <div {{bind-attr class=barClassName style=barStyle}}></div>
 {{/if}}
-{{#each spinnerClassNames as |spinnerClassName|}}
-  <div class={{spinnerClassName}}>
+{{#each spinnerClassName in spinnerClassNames}}
+  <div {{bind-attr class=spinnerClassName}}>
     <div class="circle-clipper left">
       <div class="circle"></div>
     </div><div class="gap-patch">

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-cli-materialize",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.11.0",
+    "ember": "1.10.0",
     "ember-data": "1.0.0-beta.16.1",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
@@ -15,6 +15,7 @@
     "materialize": "~0.96.0"
   },
   "resolutions": {
-    "jquery": "~1.11.1"
+    "jquery": "~1.11.1",
+    "ember": "1.10.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,34 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'ember-1.10',
+      dependencies: {
+        'ember': '1.10.0'
+      }
+    },
+    {
+      name: 'ember-1.11.0',
+      dependencies: {
+        'ember': '1.11.0'
+      }
+    },
+    {
+      name: 'ember-stable',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: { // Resolutions are only necessary when they do not match the version specified in `dependencies`
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: { // Resolutions are only necessary when they do not match the version specified in `dependencies`
+        'ember': 'beta'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "ember-cli-sass": "^3.2.2",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2"
+    "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.3"
   },
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
   "keywords": [


### PR DESCRIPTION
This pull request
* Removes all uses of attribute binding, which was breaking compatibility with ember 1.10
* Introduces the ember-try addon, to run tests against multiple versions of ember
* Configures ember-try to test this addon against `1.10.0`, `1.11.0`, `release` (currently 1.11.1) and `beta` (currently 1.12.beta-1)
* Lowers the required version of ember for this addon to 1.10 (was previously 1.11)
* Configures travis-ci to run `ember try:testall` in CI, so that only changes that pass all supported versions of ember are shown as passing pull requests. This means we'll be alerted to any further 1.10 incompatibilities