### PR TITLE
Fix blueprint

### DIFF
--- a/blueprints/ember-cli-materialize/files/config/environment.js
+++ b/blueprints/ember-cli-materialize/files/config/environment.js
@@ -2,7 +2,7 @@
 
 module.exports = function(environment) {
   var ENV = {
-    modulePrefix: '<%= modulePrefix %>',
+    modulePrefix: '<%= dasherizedPackageName %>',
     environment: environment,
     baseURL: '/',
     locationType: 'auto',


### PR DESCRIPTION
Fixes #50 

Looks like part of the app blueprint was copied over from ember-cli to start this addon's ember-cli-materialize blueprint, but we don't have access to the modulePrefix local variable, since our blueprint's index.js doesn't override the `locals` hook with anything special.

https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/index.js#L16