### PR TITLE
Pagination

### DIFF
--- a/addon/components/materialize-pagination.js
+++ b/addon/components/materialize-pagination.js
@@ -1,0 +1,77 @@
+import Ember from 'ember';
+import layout from '../templates/components/materialize-pagination';
+
+export default Ember.Component.extend({
+  min: 1,
+  max: 1,
+  current: 1,
+  range: 5,
+  layout: layout,
+  tagName: 'ul',
+  classNames: ['pagination'],
+
+  windowRange: Ember.computed('min', 'max', 'range', 'current', function () {
+    var max = this.get('max');
+    var min = this.get('min');
+    var range = this.get('range');
+    var current = this.get('current');
+
+    var middle = Math.floor((max - min)/2);
+    var low = Math.max(min, current - Math.floor(range/2));
+    var high = Math.min(max, current + Math.floor(range/2));
+
+    if (high-low < range-1) {
+      if (current <= middle) {
+        high = Math.min(max, low + range-1);
+      }
+      else {
+        low = Math.max(min, high - (range-1));
+      }
+    }
+    return {
+      low, high
+    };
+  }),
+
+  _pages: Ember.computed('windowRange.low', 'windowRange.high', 'current', function () {
+    var a = Ember.A();
+    var winRange = this.get('windowRange');
+    var current = this.get('current');
+    for (var i = winRange.low; i <= winRange.high; i +=1) {
+      a.addObject({val: i, cssClass: (current === i ? 'active' : 'waves-effect')});
+    }
+    return a;
+  }).readOnly(),
+
+  _canGoBack: Ember.computed('min', 'current', function () {
+    return this.get('current') > this.get('min');
+  }),
+
+  _canGoFwd: Ember.computed('max', 'current', function () {
+    return this.get('current') < this.get('max');
+  }),
+
+  incrementClass: Ember.computed('_canGoFwd', function() {
+    return this.get('_canGoFwd') ? '' : 'disabled';
+  }),
+
+  decrementClass: Ember.computed('_canGoBack', function() {
+    return this.get('_canGoBack') ? '' : 'disabled';
+  }),
+
+  actions: {
+    oneBack() {
+      if (this.get('_canGoBack')) {
+        this.decrementProperty('current');
+      }
+    },
+    oneFwd() {
+      if (this.get('_canGoFwd')) {
+        this.incrementProperty('current');
+      }
+    },
+    gotoPage(pagenum) {
+      this.set('current', pagenum);
+    }
+  }
+});

--- a/addon/templates/components/materialize-pagination.hbs
+++ b/addon/templates/components/materialize-pagination.hbs
@@ -1,0 +1,17 @@
+<li {{bind-attr class=decrementClass}}>
+  <a {{action 'oneBack'}}  class='decrement'>
+    <i class="mdi-navigation-chevron-left"></i>
+  </a>
+</li>
+{{#each _pages as |page|}}
+  <li {{bind-attr class=page.cssClass}}>
+    <a {{action 'gotoPage' page.val}}>
+      {{page.val}}
+    </a>
+  </li>
+{{/each}}
+<li {{bind-attr class=incrementClass}}>
+  <a {{action 'oneFwd'}}  class='increment'>
+    <i class="mdi-navigation-chevron-right"></i>
+  </a>
+</li>

--- a/app/components/materialize-pagination.js
+++ b/app/components/materialize-pagination.js
@@ -1,0 +1,3 @@
+import materializePagination from 'ember-cli-materialize/components/materialize-pagination';
+
+export default materializePagination;

--- a/tests/dummy/app/controllers/pagination.js
+++ b/tests/dummy/app/controllers/pagination.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['page'],
+  page: 1
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -14,6 +14,7 @@ Router.map(function() {
   this.route("input");
   this.route("loader");
   this.route("navbar");
+  this.route("pagination");
   this.route("parallax");
   this.route("tabs");
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -65,6 +65,10 @@
         Loader{{#materialize-badge class="new"}}1{{/materialize-badge}}
       {{/link-to}}
 
+      {{#link-to 'pagination' class="collection-item"}}
+        Pagination{{#materialize-badge class="new"}}1{{/materialize-badge}}
+      {{/link-to}}
+
       {{#link-to 'parallax' class="collection-item"}}
         Parallax{{#materialize-badge class="new"}}1{{/materialize-badge}}
       {{/link-to}}

--- a/tests/dummy/app/templates/pagination.hbs
+++ b/tests/dummy/app/templates/pagination.hbs
@@ -1,0 +1,52 @@
+<div class="section index-banner">
+    <div class="container">
+        <div class="row">
+            <div class="col s12 m9">
+                <h1 class="header">Pagination</h1>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class='container'>
+    <div class="section">
+        <div class="intro">
+            <h4 class="col s12 header">The component supports two options:</h4>
+            <ul>
+                <li>min, default value <span class="default-value badge">1</span></li>
+                <li>max, default value <span class="default-value badge">1</span></li>
+                <li>current, default value <span class="default-value badge">1</span></li>
+                <li>range, default value <span class="default-value badge">5</span></li>
+            </ul>
+        </div>
+    </div>
+    <div class="section">
+        <h4 class="col s12 header">Pagination</h4>
+        <div class="copyright-example">
+
+          <div class="row">
+            <div class="col s12">
+          {{materialize-pagination min=1 max=12 current=page range=7}}
+            </div>
+          </div>
+
+
+          <pre class=" language-markup">
+            <code class=" col s12 language-markup">
+  import Ember from 'ember';
+
+  export default Ember.Controller.extend({
+    queryParams: ['page'],
+    page: 1
+  });
+            </code>
+          </pre>
+
+          <pre class=" language-markup">
+            <code class=" col s12 language-markup">
+  <span>&#123;&#123;</span>materialize-pagination min=1 max=100 current=3 range=5<span>&#125;&#125;</span>
+            </code>
+          </pre>
+        </div>
+    </div>
+</div>

--- a/tests/unit/components/materialize-pagination-test.js
+++ b/tests/unit/components/materialize-pagination-test.js
@@ -1,0 +1,88 @@
+import Ember from 'ember';
+
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('materialize-pagination', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('window range calculation', function(assert) {
+  assert.expect(3);
+
+  // Creates the component instance
+  var component = this.subject({
+    min: 1,
+    max: 12,
+    current: 2,
+    range: 5
+  });
+  assert.deepEqual(component.get('windowRange'), {low: 1, high: 5}, 'Off center window range calculates correctly');
+  Ember.run(function () {
+
+    component.setProperties({
+      min: 1,
+      max: 12,
+      current: 7,
+      range: 5
+    });
+    assert.deepEqual(component.get('windowRange'), {low: 5, high: 9}, 'Changes to current position updates window range');
+
+    component.setProperties({
+      min: 1,
+      max: 12,
+      current: 7,
+      range: 7
+    });
+    assert.deepEqual(component.get('windowRange'), {low: 4, high: 10}, 'Changes to range width updates window range');
+
+  });
+
+});
+
+test('increment button', function(assert) {
+  assert.expect(5);
+
+  // Creates the component instance
+  var component = this.subject({
+    min: 1,
+    max: 12,
+    current: 2,
+    range: 5
+  });
+  this.render();
+  Ember.run( function () {
+    component.$('.increment').click();
+    assert.equal(component.get('current'), 3, 'Increment button incremenets position');
+    component.$('.decrement').click();
+    component.$('.decrement').click();
+    assert.equal(component.get('current'), 1, 'Decrement button incremenets position');
+    assert.equal(component.$('li.disabled').length, 1, 'Decrement button disables at lower edge of range');
+    component.set('current', 7);
+    Ember.run.schedule('afterRender', function () {
+      assert.equal(component.$('li.disabled').length, 0, 'No buttons disabled in middle of range');
+      component.set('current', 12);
+      Ember.run.schedule('afterRender', function () {
+        assert.equal(component.$('li.disabled').length, 1, 'Increment button disables at upper edge of range');
+      });
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
A pagination component that automatically calculates a range of pages to jump to, based on a min, a max, and a "width" of the window of page numbers. As the boundaries of the allowed range are approached, the "back" and "forward" buttons grey out and disable.

On the demo page, I provide an example of how to use a query param on a `Ember.Controller` in conjunction with this component, since it's likely to be the most common use case.

```handlebars
{{materialize-pagination min=1 max=12 current=page range=7}}
```

![screen shot 2015-04-13 at 1 16 19 am](https://cloud.githubusercontent.com/assets/558005/7112380/e95d62b6-e17d-11e4-9b53-0e797774058b.png)
![screen shot 2015-04-13 at 1 16 11 am](https://cloud.githubusercontent.com/assets/558005/7112382/e95fc77c-e17d-11e4-9924-a171c7e936ea.png)
![screen shot 2015-04-13 at 1 16 02 am](https://cloud.githubusercontent.com/assets/558005/7112381/e95fcf88-e17d-11e4-82c8-d2f26dc760dd.png)