### PR TITLE
Update travis.yml to use PhantomJS 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: node_js
 node_js:
   - "0.12"
-  - "iojs-v1.6.4"
+  - "iojs"
 
 sudo: false
 
@@ -11,6 +11,10 @@ cache:
     - node_modules
 
 before_install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 


### PR DESCRIPTION
PhantomJS 2.0.0 is less error prone, and more performant than 1.9.8