### PR TITLE
Re-enable stylesheet in qunit test runner

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -67,3 +67,16 @@ span.badge {
     content: "\""+ $mdi-icon-value +"\"";
   }
 }
+
+// Qunit test runner style fixes
+#qunit-testrunner-toolbar {
+  [type="checkbox"] + label {
+    margin-left: 25px;
+    &:before {
+      left: -20px;
+    }
+  }
+  #qunit-modulefilter {
+    display: inherit;
+  }
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,7 +11,7 @@
     {{content-for 'test-head'}}
 
     <link rel="stylesheet" href="assets/vendor.css">
-    <!-- <link rel="stylesheet" href="assets/dummy.css"> -->
+    <link rel="stylesheet" href="assets/dummy.css">
     <link rel="stylesheet" href="assets/test-support.css">
 
     {{content-for 'head-footer'}}


### PR DESCRIPTION
We should be using our CSS in our test runner, to validate that things look correct in acceptance tests.

Unfortunately, materialize screws up the test runner by styling naked tags and inputs
![screen shot 2015-04-14 at 9 57 45 pm](https://cloud.githubusercontent.com/assets/558005/7152484/a09e6dac-e2f1-11e4-8418-efb697051b9d.png)
The most annoying part is that the module selector disappears completely. I have added some styles to our dummy app to fix this
![screen shot 2015-04-14 at 9 57 32 pm](https://cloud.githubusercontent.com/assets/558005/7152486/aa5edf34-e2f1-11e4-8846-483a19ac7c67.png)

We should consider shipping this CSS with ember-cli-materialize, so that our addon consumers don't suffer from the same problems in their own qunit test runners.