### PR TITLE
New CP syntax, cleanup, formatting

### DIFF
--- a/addon/components/md-btn-submit.js
+++ b/addon/components/md-btn-submit.js
@@ -1,6 +1,6 @@
-import materializeButton from './md-btn';
+import MaterializeButton from './md-btn';
 
-export default materializeButton.extend({
+export default MaterializeButton.extend({
   layoutName: 'components/materialize-button',
   tagName: 'button',
   attributeBindings: ['type'],

--- a/addon/components/md-btn.js
+++ b/addon/components/md-btn.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-btn';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
   layout: layout,
@@ -15,18 +16,22 @@ export default Ember.Component.extend({
 
   didInsertElement(){
     this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, function(){
-      var Waves = window.Waves || {};
-      if(Ember.typeOf(Waves.displayEffect) === 'function'){
-        Waves.displayEffect();
-      }
-    });
+    Ember.run.scheduleOnce('afterRender', this, this._setupWaves);
   },
 
-  buttonClass: Ember.computed('buttonType', function(){
-    var buttonType = this.get('buttonType');
-    return buttonType ? `btn-${buttonType}` : 'btn';
+  buttonClass: computed('buttonType', {
+    get() {
+      var buttonType = this.get('buttonType');
+      return buttonType ? `btn-${buttonType}` : 'btn';
+    }
   }),
+
+  _setupWaves() {
+    var Waves = window.Waves || {};
+    if(Ember.typeOf(Waves.displayEffect) === 'function'){
+      Waves.displayEffect();
+    }
+  },
 
   click() {
     this.sendAction();

--- a/addon/components/md-card-collapsible.js
+++ b/addon/components/md-card-collapsible.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-card-collapsible';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
   layout: layout,
@@ -8,19 +9,29 @@ export default Ember.Component.extend({
   attributeBindings: ['data-collapsible'],
   accordion: true,
 
-  'data-collapsible': Ember.computed(function() {
-    return (this.get('accordion')) ? 'accordion' : 'expandable';
+  'data-collapsible': computed({
+    get() {
+      return this.get('accordion') ? 'accordion' : 'expandable';
+    }
   }),
 
   didInsertElement() {
     this._super(...arguments);
-    var isAccordion = this.get('accordion');
-    this.$().collapsible({ accordion : isAccordion });
+    this._setupCollapsible();
   },
 
-  willDestroyElement: function() {
-    var $panel_headers = this.$().find('> li > .collapsible-header');
+  _setupCollapsible() {
+    this.$().collapsible({ accordion : this.get('accordion') });
+  },
+
+  _teardownCollapsible() {
+    var $panel_headers = this.$('> li > .collapsible-header');
     this.$().off('click.collapse', '.collapsible-header');
     $panel_headers.off('click.collapse');
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+    this._teardownCollapsible();
   }
 });

--- a/addon/components/md-card-content.js
+++ b/addon/components/md-card-content.js
@@ -1,16 +1,22 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-card-content';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
   layout: layout,
+
   classNames: ['card-content'],
+
   classNameBinding: 'class',
   titleBinding: 'parentView.title',
   titleClassBinding: 'parentView.titleClass',
   activatorBinding: 'parentView.activator',
-  cardTitleClass: Ember.computed('titleClass', function() {
-    var clz = this.get('titleClass');
-    return (clz) ? clz : 'black-text';
+
+  cardTitleClass: computed('titleClass',{
+    get() {
+      var clz = this.get('titleClass');
+      return (clz) ? clz : 'black-text';
+    }
   })
 });
 

--- a/addon/components/md-card-panel.js
+++ b/addon/components/md-card-panel.js
@@ -3,7 +3,9 @@ import layout from '../templates/components/md-card-panel';
 
 export default Ember.Component.extend({
   layout: layout,
+
   classNames: ['card-panel'],
+
   classNameBinding: 'class'
 });
 

--- a/addon/components/md-card-reveal.js
+++ b/addon/components/md-card-reveal.js
@@ -4,7 +4,9 @@ import layout from '../templates/components/md-card-reveal';
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'div',
+
   classNames: ['card-reveal'],
+
   classNameBinding: 'class',
   activatorBinding: 'parentView.activator'
 });

--- a/addon/components/md-card.js
+++ b/addon/components/md-card.js
@@ -3,6 +3,8 @@ import layout from '../templates/components/md-card';
 
 export default Ember.Component.extend({
   layout: layout,
+
   classNames: ['card'],
+
   classNameBinding: 'class'
 });

--- a/addon/components/md-check.js
+++ b/addon/components/md-check.js
@@ -3,5 +3,6 @@ import layout from '../templates/components/md-checkbox';
 
 export default SelectableItem.extend({
   layout: layout,
+
   classNames: ['materialize-checkbox']
 });

--- a/addon/components/md-collapsible.js
+++ b/addon/components/md-collapsible.js
@@ -4,5 +4,6 @@ import layout from '../templates/components/md-collapsible';
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'li',
+
   classNameBindings: ['class']
 });

--- a/addon/components/md-copyright.js
+++ b/addon/components/md-copyright.js
@@ -1,26 +1,31 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-copyright';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
-  init: function() {
-    this._super(...arguments);
-    if (this.get('startYear') !== null) {
-      Ember.assert('Property startYear must be less than or equal to the current year.',
-        this.get('startYear') <= new Date().getFullYear());
-    }
-  },
   layout: layout,
   classNames: ['footer-copyright'],
+
+  init() {
+    this._super(...arguments);
+    Ember.assert('Property startYear must be less than or equal to the current year.',
+      this.get('startYear') === null ||
+      this.get('startYear') <= new Date().getFullYear());
+  },
+
   startYear: null,
   text: null,
-  date: Ember.computed(function () {
-    var currentYear = new Date().getFullYear();
-    var returnDate;
-    if (this.get('startYear') === null || this.get('startYear') === currentYear) {
-      returnDate = currentYear;
-    } else {
-      returnDate = this.get('startYear') + ' - ' + currentYear;
+
+  date: computed({
+    get() {
+      var currentYear = new Date().getFullYear();
+      var startYear = this.get('startYear');
+
+      if (startYear === null || startYear === currentYear) {
+        return '' + currentYear;
+      } else {
+        return `${startYear} - ${currentYear}`;
+      }
     }
-    return returnDate;
-  }).readOnly()
+  })
 });

--- a/addon/components/md-input-date.js
+++ b/addon/components/md-input-date.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/md-input-date';
 
 export default MaterializeInput.extend({
   layout: layout,
+
   selectMonths: true,
   numberOfYears: 15,
   min: '',
@@ -10,15 +11,22 @@ export default MaterializeInput.extend({
 
   didInsertElement() {
     this._super(...arguments);
+    this._setupPicker();
+  },
 
+  willDestroyElement() {
+    this._super(...arguments);
+    this._teardownPicker();
+  },
+
+  _setupPicker() {
     var datePickerOptions = this.getProperties('selectMonths', 'numberOfYears', 'min', 'max');
     datePickerOptions.selectYears = datePickerOptions.numberOfYears;
     this.$('.datepicker').pickadate(datePickerOptions);
   },
 
-  willDestroyElement: function() {
+  _teardownPicker() {
     var $pickadate = this.$('.datepicker').data('pickadate');
-
     if ($pickadate) {
       $pickadate.stop();
     }

--- a/addon/components/md-input-field.js
+++ b/addon/components/md-input-field.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
+  classNames: ['input-field'],
 
   bindAttributes: ['disabled', 'readonly'],
-  classNames: ['input-field'],
   validate: false,
+
+  errorsPath: 'errors',
 
   init() {
     this._super(...arguments);
@@ -14,7 +17,7 @@ export default Ember.Component.extend({
     //  or propose a framework modification to support this in the long term
     var propertyPath = this.get('valueBinding._label');
     if (Ember.isPresent(propertyPath)) {
-      Ember.Binding.from('targetObject.errors.' + propertyPath)
+      Ember.Binding.from(`targetObject.${this.get('errorsPath')}.${propertyPath}`)
         .to('errors')
         .connect(this);
     }
@@ -24,12 +27,21 @@ export default Ember.Component.extend({
     this._super(...arguments);
     // pad the errors element when an icon is present
     if (Ember.isPresent(this.get('icon'))) {
-      this.$('>span').css('padding-left', '3rem');
+      this.$('> span').css('padding-left', '3rem');
     }
   },
 
-  id: Ember.computed(function() {
-    return `${this.get('elementId')}-input`;
-  })
+  id: computed('elementId', {
+    get() {
+      return `${this.get('elementId')}-input`;
+    }
+  }),
+
+  _setupLabel() {
+    var labelSelector = this.$('> label');
+    if (Ember.isPresent(this.get('value')) && !labelSelector.hasClass('active')) {
+      labelSelector.addClass('active');
+    }
+  }
 
 });

--- a/addon/components/md-input.js
+++ b/addon/components/md-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import MaterializeInputField from './md-input-field';
 import layout from '../templates/components/md-input';
 
@@ -9,9 +8,6 @@ export default MaterializeInputField.extend({
   didInsertElement() {
     this._super(...arguments);
     // make sure the label moves when a value is bound.
-    var labelSelector = this.$('>label');
-    if (Ember.isPresent(this.get('value')) && !labelSelector.hasClass('active')) {
-      labelSelector.addClass('active');
-    }
+    this._setupLabel();
   }
 });

--- a/addon/components/md-loader.js
+++ b/addon/components/md-loader.js
@@ -1,48 +1,61 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-loader';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
   layout: layout,
+
+  classNameBindings: ['isBarType:progress:preloader-wrapper', 'active:active', 'size'],
+
   mode: 'indeterminate',
   percent: 0,
   size: 'big',
   active: true,
   color: null,
-  classNameBindings: ['isBarType:progress:preloader-wrapper', 'active:active', 'size'],
 
-  isBarType: Ember.computed('mode', function () {
-    return ['determinate', 'indeterminate'].indexOf(this.get('mode')) >= 0;
-  }),
-
-  isDeterminate: Ember.computed('mode', function () {
-    return ['determinate'].indexOf(this.get('mode'));
-  }),
-
-  barStyle: Ember.computed('mode', 'percent', function () {
-    if (this.get('mode') === 'determinate') {
-      return `width: ${this.get('percent')}%`;
-    }
-    else {
-      return null;
+  isBarType: computed('mode', {
+    get() {
+      return ['determinate', 'indeterminate'].indexOf(this.get('mode')) >= 0;
     }
   }),
 
-  barClassName: Ember.computed('isBarType', 'mode', function () {
-    return this.get('isBarType') ? this.get('mode') : null;
+  isDeterminate: computed('mode', {
+    get() {
+      return ['determinate'].indexOf(this.get('mode'));
+    }
   }),
 
-  spinnerClassNames: Ember.computed('color', 'isBarType', function () {
-    if (!this.get('isBarType')) {
-      var color = this.get('color');
-      if (!color) {
-        return Ember.A(['blue', 'red', 'green', 'yellow'].map((c) => (`spinner-layer spinner-${c}`)));
+  barStyle: computed('mode', 'percent', {
+    get() {
+      if (this.get('mode') === 'determinate') {
+        return `width: ${this.get('percent')}%`;
       }
       else {
-        return Ember.A([`spinner-layer spinner-${color}-only`]);
+        return null;
       }
     }
-    else {
-      return Ember.A();
+  }),
+
+  barClassName: computed('isBarType', 'mode', {
+    get() {
+      return this.get('isBarType') ? this.get('mode') : null;
+    }
+  }),
+
+  spinnerClassNames: computed('color', 'isBarType', {
+    get() {
+      if (!this.get('isBarType')) {
+        var color = this.get('color');
+        if (!color) {
+          return Ember.A(['blue', 'red', 'green', 'yellow'].map((c) => (`spinner-layer spinner-${c}`)));
+        }
+        else {
+          return Ember.A([`spinner-layer spinner-${color}-only`]);
+        }
+      }
+      else {
+        return Ember.A();
+      }
     }
   })
 });

--- a/addon/components/md-modal.js
+++ b/addon/components/md-modal.js
@@ -1,16 +1,21 @@
-import Ember from 'ember';
 import YappModal from 'ember-modal-dialog/components/modal-dialog';
 import layout from '../templates/components/md-modal';
+import computed from 'ember-new-computed';
 
 export default YappModal.extend({
   layout: layout,
+
   destinationElementId: "materialize-modal-root-element",
   acceptsKeyResponder: true,
   overlayId: 'lean-modal',
   attributeBindings: ['style:inlineStyle'],
-  inlineStyle: Ember.computed(function() {
+
+  inlineStyle: computed({
+    get() {
       return 'z-index: 1000;';
+    }
   }),
+
   didInsertElement() {
     this._super(...arguments);
     this.becomeKeyResponder();

--- a/addon/components/md-navbar.js
+++ b/addon/components/md-navbar.js
@@ -7,12 +7,20 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, function(){
-      if(Ember.typeOf(Ember.$('.button-collapse').sideNav) === 'function'){
-        this.$('.button-collapse').sideNav({
-          closeOnClick: true
-        });
-      }
-    });
+    //TODO: is this scheduling necessary?
+    Ember.run.scheduleOnce('afterRender', this, this._setupNavbar);
+  },
+
+  _setupNavbar() {
+    if(Ember.typeOf(Ember.$('.button-collapse').sideNav) === 'function'){
+      this.$('.button-collapse').sideNav({
+        closeOnClick: true
+      });
+    }
   }
+
+  //TODO: Unregister any listeners that $.sideNav() puts in place
+  // _teardownNavbar() {
+  //
+  // }
 });

--- a/addon/components/md-pagination.js
+++ b/addon/components/md-pagination.js
@@ -1,62 +1,79 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-pagination';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
+  layout: layout,
+
+  classNames: ['pagination'],
+
   min: 1,
   max: 1,
   current: 1,
   range: 5,
-  layout: layout,
   tagName: 'ul',
-  classNames: ['pagination'],
 
-  windowRange: Ember.computed('min', 'max', 'range', 'current', function () {
-    var max = this.get('max');
-    var min = this.get('min');
-    var range = this.get('range');
-    var current = this.get('current');
 
-    var middle = Math.floor((max - min)/2);
-    var low = Math.max(min, current - Math.floor(range/2));
-    var high = Math.min(max, current + Math.floor(range/2));
+  windowRange: computed('min', 'max', 'range', 'current', {
+    get() {
+      //TODO: this should be broken out into a util, so that it can be tested independently
+      var max = this.get('max');
+      var min = this.get('min');
+      var range = this.get('range');
+      var current = this.get('current');
 
-    if (high-low < range-1) {
-      if (current <= middle) {
-        high = Math.min(max, low + range-1);
+      var middle = Math.floor((max - min)/2);
+      var low = Math.max(min, current - Math.floor(range/2));
+      var high = Math.min(max, current + Math.floor(range/2));
+
+      if (high-low < range-1) {
+        if (current <= middle) {
+          high = Math.min(max, low + range-1);
+        }
+        else {
+          low = Math.max(min, high - (range-1));
+        }
       }
-      else {
-        low = Math.max(min, high - (range-1));
+      return {
+        low, high
+      };
+    }
+  }),
+
+  _pages: computed('windowRange.low', 'windowRange.high', 'current', {
+    get() {
+      var a = Ember.A();
+      var winRange = this.get('windowRange');
+      var current = this.get('current');
+      for (var i = winRange.low; i <= winRange.high; i +=1) {
+        a.addObject({val: i, cssClass: (current === i ? 'active' : 'waves-effect')});
       }
+      return a;
     }
-    return {
-      low, high
-    };
   }),
 
-  _pages: Ember.computed('windowRange.low', 'windowRange.high', 'current', function () {
-    var a = Ember.A();
-    var winRange = this.get('windowRange');
-    var current = this.get('current');
-    for (var i = winRange.low; i <= winRange.high; i +=1) {
-      a.addObject({val: i, cssClass: (current === i ? 'active' : 'waves-effect')});
+  _canGoBack: computed('min', 'current', {
+    get() {
+      return this.get('current') > this.get('min');
     }
-    return a;
-  }).readOnly(),
-
-  _canGoBack: Ember.computed('min', 'current', function () {
-    return this.get('current') > this.get('min');
   }),
 
-  _canGoFwd: Ember.computed('max', 'current', function () {
-    return this.get('current') < this.get('max');
+  _canGoFwd: computed('max', 'current', {
+    get() {
+      return this.get('current') < this.get('max');
+    }
   }),
 
-  incrementClass: Ember.computed('_canGoFwd', function() {
-    return this.get('_canGoFwd') ? '' : 'disabled';
+  incrementClass: computed('_canGoFwd', {
+    get() {
+      return this.get('_canGoFwd') ? '' : 'disabled';
+    }
   }),
 
-  decrementClass: Ember.computed('_canGoBack', function() {
-    return this.get('_canGoBack') ? '' : 'disabled';
+  decrementClass: computed('_canGoBack', {
+    get() {
+      return this.get('_canGoBack') ? '' : 'disabled';
+    }
   }),
 
   actions: {

--- a/addon/components/md-parallax.js
+++ b/addon/components/md-parallax.js
@@ -7,6 +7,15 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
+    this._setupParallax();
+  },
+
+  _setupParallax() {
     this.$('.parallax').parallax();
-  }
+  },
+
+  //TODO: unregister any listeners that $.parallax() registers
+  // _teardownParallax() {
+  //
+  // }
 });

--- a/addon/components/md-radio.js
+++ b/addon/components/md-radio.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import SelectableItem from './selectable-item';
 import layout from '../templates/components/md-radio';
+import computed from 'ember-new-computed';
 
 export default SelectableItem.extend({
   layout: layout,
@@ -10,9 +11,11 @@ export default SelectableItem.extend({
 
   className: ['materialize-radio'],
 
-  checked: Ember.computed('groupValue', 'value', function () {
-    return this.get('groupValue') === this.get('value');
-  }).readOnly(),
+  checked: computed('groupValue', 'value', {
+    get() {
+      return this.get('groupValue') === this.get('value');
+    }
+  }),
 
   didInsertElement() {
     this._super(...arguments);

--- a/addon/components/md-range.js
+++ b/addon/components/md-range.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import layout from '../templates/components/md-range';
 
 export default Ember.Component.extend({
+  layout: layout,
+
+  classNames: ['range-field'],
+
   min: 0,
   max: 100,
-  step: 5,
-  layout: layout,
-  classNames: ['range-field']
+  step: 5
 });

--- a/addon/components/md-select.js
+++ b/addon/components/md-select.js
@@ -7,9 +7,20 @@ export default MaterializeInputField.extend({
 
   didInsertElement() {
     this._super(...arguments);
+    this._setupSelect();
+  },
+
+  _setupSelect() {
     this.$('select').material_select();
   },
 
+  //TODO: clean up any listeners that $.select() puts in place
+  // _teardownSelect() {
+  //
+  // }
+
+  //TODO: this could be converted to a computed property, returning a string
+  //  that is bound to the class attribute of the inputSelector
   errorsDidChange: Ember.observer('errors', function() {
     var inputSelector = this.$('input');
     // monitor the select's validity and copy the appropriate validation class to the materialize input element.

--- a/addon/components/md-switch.js
+++ b/addon/components/md-switch.js
@@ -1,15 +1,19 @@
-import Ember from 'ember';
 import SelectableItem from './selectable-item';
 import layout from '../templates/components/md-switch';
+import computed from 'ember-new-computed';
 
 export default SelectableItem.extend({
   layout: layout,
+
+  classNames: ['switch', 'materialize-switch'],
+
   offLabel: 'Off',
   onLabel: 'On',
   disabled: false,
 
-  classNames: ['switch', 'materialize-switch'],
-  _labelClass: Ember.computed('name', function () {
-    return this.get('name') ? 'right' : '';
+  _labelClass: computed('name', {
+    get() {
+      return this.get('name') ? 'right' : '';
+    }
   })
 });

--- a/addon/components/md-tab.js
+++ b/addon/components/md-tab.js
@@ -1,32 +1,44 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-tab';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
-  layout: layout,
   tagName: 'li',
+  layout: layout,
+
   classNames: ['materialize-tabs-tab', 'tab', 'col'],
   classNameBindings: ['_colClass'],
 
   colWidth: Ember.computed.alias('_tabSet.colWidth'),
 
-  _colClass: Ember.computed('colWidth', function () {
-    return 's' + this.get('colWidth');
-  }),
-
-  _tabSet: Ember.computed(function () {
-    return this.nearestWithProperty('___materializeTabs');
-  }),
-
-  _active: Ember.computed('_tabSet.selected', 'value', function () {
-    return this.get('_tabSet.selected') === this.get('value');
-  }),
+  didInsertElement() {
+    this._super(...arguments);
+    this._registerTab();
+  },
 
   click() {
     this.trigger('tabClicked', this);
   },
 
-  didInsertElement() {
-    this._super(...arguments);
+  _colClass: computed('colWidth', {
+    get() {
+      return `s${this.get('colWidth')}`;
+    }
+  }),
+
+  _tabSet: computed({
+    get() {
+      return this.nearestWithProperty('___materializeTabs');
+    }
+  }),
+
+  _active: computed('_tabSet.selected', 'value', {
+    get() {
+      return this.get('_tabSet.selected') === this.get('value');
+    }
+  }),
+
+  _registerTab() {
     var tabSet = this.get('_tabSet');
     if (!tabSet) {
       throw new Error('materialize-tabs-tab cannot be used outside the context of a materialize-tabs');

--- a/addon/components/md-textarea.js
+++ b/addon/components/md-textarea.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputField from './md-input-field';
 import layout from '../templates/components/md-textarea';
 
@@ -8,9 +7,6 @@ export default InputField.extend({
   didInsertElement() {
     this._super(...arguments);
     // make sure the label moves when a value is bound.
-    var labelSelector = this.$('>label');
-    if (Ember.isPresent(this.get('value')) && !labelSelector.hasClass('active')) {
-      labelSelector.addClass('active');
-    }
+    this._setupLabel();
   }
 });

--- a/addon/components/selectable-item-group.js
+++ b/addon/components/selectable-item-group.js
@@ -1,14 +1,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/selectable-item-group';
+import computed from 'ember-new-computed';
 
 var get = Ember.get,
   map = Ember.EnumerableUtils.map,
   indexOf = Ember.EnumerableUtils.indexOf;
 
 export default Ember.Component.extend({
+  layout: layout,
+
   content: null,
   selection: null,
-  layout: layout,
+
   optionValuePath: 'content',
   optionLabelPath: 'content',
   multiple: false,
@@ -57,25 +60,39 @@ export default Ember.Component.extend({
     }
   },
 
-  _valuePath: Ember.computed('optionValuePath', function () {
-    var optionValuePath = get(this, 'optionValuePath');
-    return optionValuePath.replace(/^content\.?/, '');
+  _valuePath: computed('optionValuePath',  {
+    get() {
+      var optionValuePath = get(this, 'optionValuePath');
+      return optionValuePath.replace(/^content\.?/, '');
+    }
   }),
 
-  _labelPath: Ember.computed('optionLabelPath', function () {
-    var optionLabelPath = get(this, 'optionLabelPath');
-    return optionLabelPath.replace(/^content\.?/, '');
+  _labelPath: computed('optionLabelPath',  {
+    get() {
+      var optionLabelPath = get(this, 'optionLabelPath');
+      return optionLabelPath.replace(/^content\.?/, '');
+    }
   }),
 
-  _content: Ember.computed('content.[]', '_valuePath', '_labelPath',function () {
-    var valuePath = get(this, '_valuePath');
-    var labelPath = get(this, '_labelPath');
-    var content = get(this, 'content') || Ember.A([]);
+  _content: computed('content.[]', '_valuePath', '_labelPath', {
+    get() {
+      var valuePath = get(this, '_valuePath');
+      var labelPath = get(this, '_labelPath');
+      var content = get(this, 'content') || Ember.A([]);
 
-    if (valuePath && labelPath) {
-      return Ember.A(map(content, function (el) { return {value: get(el, valuePath), label: get(el, labelPath)}; }));
-    } else {
-      return Ember.A(map(content, function (el) { return {value: el, label: el}; }));
+      if (valuePath && labelPath) {
+        return Ember.A(
+          map(content, el => {
+            return {value: get(el, valuePath), label: get(el, labelPath)};
+          })
+        );
+      } else {
+        return Ember.A(
+          map(content, el => {
+            return {value: el, label: el};
+          })
+        );
+      }
     }
   })
 });

--- a/addon/components/selectable-item.js
+++ b/addon/components/selectable-item.js
@@ -41,7 +41,9 @@ export default Ember.Component.extend({
     this._setupLabel();
   },
 
-  group: Ember.computed(function () {
-    return this.nearestWithProperty('__materializeSelectableItemGroup');
+  group: computed({
+    get() {
+      return this.nearestWithProperty('__materializeSelectableItemGroup');
+    }
   })
 });

--- a/addon/mixins/group-selectable-item.js
+++ b/addon/mixins/group-selectable-item.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
+var alias = Ember.computed.alias;
+
 export default Ember.Mixin.create({
-  name: Ember.computed.alias('content.label'),
-  value: Ember.computed.alias('content.value'),
-  disabled: Ember.computed.alias('group.disabled')
+  name: alias('content.label'),
+  value: alias('content.value'),
+  disabled: alias('group.disabled')
 });

--- a/tests/integration/collapsible-test.js
+++ b/tests/integration/collapsible-test.js
@@ -15,7 +15,9 @@ module('Acceptance - Collapsible', {
 });
 
 test('Collapsible basic tests', function(assert) {
-  visit('/collapsible').then(function() {
+  visit('/collapsible');
+
+  andThen(function() {
     assert.equal(find('#accordion>li').length, 3, 'Accordion should have 3 headers');
     assert.equal(find('#expandable>li').length, 3, 'Expandable should have 3 headers');
     assert.equal(find('#preselected>li').length, 3, 'Preselected should have 3 headers');


### PR DESCRIPTION
* Switched us over to the new computed property syntax introduced in ember 1.12 - https://github.com/stefanpenner/rfcs/blob/ae07e7b1ce1996686c91250ebb2158a4eff4bce0/0000-improved-cp-syntax.md
* Found a few places where `this._super(...arguments)` was not called in `willDestroyElement`, `didInsertElement`, or `init` hook
* TODO'd some places where we're likely setting up listeners via materialize JavaScript on `didInsertElement`, and not properly tearing them down in `willDestroyElement`
* More ES6ification: converted string concatination to template strings, callbacks to arrow functions, etc...
