### PR TITLE
[Refactor] Remove liquid fire

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "ember-key-responder": "0.2.1",
     "ember-modal-dialog": "0.3.0",
     "ember-radio-button": "1.0.4",
-    "ember-try": "0.0.3",
-    "liquid-fire": "https://github.com/ef4/liquid-fire.git#8fcefd057478ab6852d7b8b3fc8526aa5079553c"
+    "ember-try": "0.0.3"
   },
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
   "keywords": [


### PR DESCRIPTION
Materialize already gives us velocity.js, which is used in our tabs component. Liquid-fire is awesome, and the best ember-idiomatic option for material-design-ish animations and transitions, but we don't need it for now. 