### PR TITLE
[Bugfix] Select - simple array case

### DIFF
--- a/addon/components/md-select.js
+++ b/addon/components/md-select.js
@@ -5,6 +5,9 @@ import layout from '../templates/components/md-select';
 export default MaterializeInputField.extend({
   layout: layout,
 
+  optionLabelPath: 'content',
+  optionValuePath: 'content',
+
   didInsertElement() {
     this._super(...arguments);
     this._setupSelect();

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "ember-key-responder": "0.2.1",
     "ember-modal-dialog": "0.3.0",
     "ember-radio-button": "1.0.4",
-    "ember-try": "0.0.3",
-    "liquid-fire": "https://github.com/ef4/liquid-fire.git#8fcefd057478ab6852d7b8b3fc8526aa5079553c"
+    "ember-try": "0.0.3"
   },
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
   "keywords": [

--- a/tests/unit/components/materialize-checkboxes-test.js
+++ b/tests/unit/components/materialize-checkboxes-test.js
@@ -29,6 +29,17 @@ test('it renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
+test('simple array test', function (assert) {
+  var component = this.subject({
+    content: Ember.A(['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan']),
+    selection: Ember.A(['Harry Morgan'])
+  });
+  this.render();
+  assert.deepEqual(this.$('label').toArray().map(x => Ember.$(x).text()), ['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan'], 'Choices are valid');
+  assert.equal(this.$('input[type="checkbox"]')[2].checked, true, 'Third checkbox is checked');
+});
+
+
 disabledGroupTest();
 groupItemsRenderTest();
 initialSelectionTest(Ember.A(['bbb', 'ccc']));

--- a/tests/unit/components/materialize-radios-test.js
+++ b/tests/unit/components/materialize-radios-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleForComponent,
   test
@@ -27,6 +29,18 @@ test('it renders', function(assert) {
   this.render();
   assert.equal(component._state, 'inDOM');
 });
+
+test('simple array test', function (assert) {
+  var component = this.subject({
+    content: Ember.A(['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan']),
+    selection: 'Harry Morgan'
+  });
+  this.render();
+
+  assert.deepEqual(this.$('label').toArray().map(x => Ember.$(x).text().trim()), ['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan'], 'Choices are valid');
+  assert.equal(this.$('input[type="radio"]')[2].checked, true, 'Third radio is checked');
+});
+
 
 disabledGroupTest();
 groupItemsRenderTest();

--- a/tests/unit/components/materialize-select-test.js
+++ b/tests/unit/components/materialize-select-test.js
@@ -44,3 +44,20 @@ test('select label is active with value', function(assert) {
   this.render();
   assert.ok(component.$('>label').hasClass('active'));
 });
+
+test('select creates the correct choices from a simple content array', function(assert) {
+
+  var component = this.subject({
+    content: new Ember.A(['Walter White', 'Jesee Pinkman', 'Gus Freng']),
+    value: 'Jesee Pinkman'
+  });
+  this.render();
+  assert.equal(component.$('input').val(), 'Jesee Pinkman', 'Initially selected value is correct');
+
+  assert.deepEqual(
+    this.$('.dropdown-content li span').toArray().map(x => x.innerText),
+    ['Walter White', 'Jesee Pinkman', 'Gus Freng'],
+    'Choices are valid'
+  );
+
+});

--- a/tests/unit/components/materialize-switches-test.js
+++ b/tests/unit/components/materialize-switches-test.js
@@ -29,6 +29,16 @@ test('it renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
+test('simple array test', function (assert) {
+  var component = this.subject({
+    content: Ember.A(['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan']),
+    selection: Ember.A(['Deborah Morgan'])
+  });
+  this.render();
+  assert.deepEqual(this.$('.switch-label').toArray().map(x => Ember.$(x).text()), ['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan'], 'Choices are valid');
+  assert.equal(this.$('input[type="checkbox"]')[1].checked, true, 'Second checkbox is checked');
+});
+
 disabledGroupTest();
 groupItemsRenderTest();
 initialSelectionTest(Ember.A(['bbb', 'ccc']));


### PR DESCRIPTION
Fixes #74 

This introduces test coverage for simple array use cases in select, switches, checks and radios.

Example: 
#### Component
```js
export default Ember.Component.extend({
  choices: ['Dexter Morgan', 'Deborah Morgan', 'Harry Morgan'],
  selectedChoice: 'Deborah Morgan'
});

```
#### Template
```handlebars
{{md-select
  content=choices
  value=selectedChoice}}
```
or
```handlebars
{{md-radios
  content=choices
  selection=selectedChoice}}
```