### PR TITLE
[Bugfix] Handle nested addons properly

### DIFF
--- a/blueprints/ember-cli-materialize/index.js
+++ b/blueprints/ember-cli-materialize/index.js
@@ -6,6 +6,14 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addPackageToProject('ember-cli-sass', '^3.3.0');
+    return this.addPackageToProject('ember-radio-button',   '1.0.4').then(function () {
+      return this.addPackageToProject('ember-new-computed',   '~1.0.0').then(function () {
+        return this.addPackageToProject('ember-key-responder',  '0.2.1').then(function () {
+          return this.addPackageToProject('ember-modal-dialog',   '0.3.0').then(function () {
+            return this.addPackageToProject('ember-cli-sass',       '^3.3.0');
+          }.bind(this));
+        }.bind(this));
+      }.bind(this));
+    }.bind(this));
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-materialize",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Nested addons should be in `dependencies`, not `devDependencies`

Fixes #79 