### PR TITLE
Modal container component, modal documentation improvements

### DIFF
--- a/addon/components/md-modal-container.js
+++ b/addon/components/md-modal-container.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import layout from '../templates/components/md-modal-container';
+
+export default Ember.Component.extend({
+  modalContainerId: 'materialize-modal-root-element',
+  layout: layout
+});

--- a/addon/templates/components/md-modal-container.hbs
+++ b/addon/templates/components/md-modal-container.hbs
@@ -1,0 +1,1 @@
+<div {{bind-attr id=modalContainerId}}></div>

--- a/app/components/md-modal-container.js
+++ b/app/components/md-modal-container.js
@@ -1,0 +1,3 @@
+import mdModalContainer from 'ember-cli-materialize/components/md-modal-container';
+
+export default mdModalContainer;

--- a/blueprints/ember-cli-materialize/files/app/templates/application.hbs
+++ b/blueprints/ember-cli-materialize/files/app/templates/application.hbs
@@ -1,0 +1,6 @@
+<h2 id="title">Welcome to Ember.js</h2>
+
+{{outlet}}
+
+{{!-- ember-cli-materialize modal container --}}
+{{md-modal-container}}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -80,3 +80,7 @@ a {
     display: inherit;
   }
 }
+
+.code-comment {
+  color: #aaa;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,6 +14,7 @@
 <main>
   {{outlet}}
 </main>
+{{md-modal-container}}
 
 <footer class="page-footer">
     <div class="container">

--- a/tests/dummy/app/templates/modal.hbs
+++ b/tests/dummy/app/templates/modal.hbs
@@ -36,7 +36,11 @@
         </div>
         <pre class=" language-markup">
           <code class=" col s12 language-markup">
-            <span>&#123;&#123;</span>#md-dialog action="closeModal"<span>&#125;&#125;</span>
+            <span class="code-comment"><span>&#123;&#123;</span>!-- in app/templates/application.hbs --<span>&#125;&#125;</span></span>
+            <span>&#123;&#123;</span>md-modal-container<span>&#125;&#125;</span>
+
+            <span class="code-comment"><span>&#123;&#123;</span>!-- in app/templates/my-view.hbs --<span>&#125;&#125;</span></span>
+            <span>&#123;&#123;</span>#md-modal action="closeModal"<span>&#125;&#125;</span>
               &lt;div class="modal-content"&gt;
                 &lt;h4&gt;Hello Modal&lt;/h4&gt;
                 &lt;p&gt;Oh hai there!&lt;/p&gt;
@@ -51,7 +55,7 @@
                   Cancel
                 &lt;/a&gt;
               &lt;/div&gt;
-            <span>&#123;&#123;</span>/md-dialog<span>&#125;&#125;</span>
+            <span>&#123;&#123;</span>/md-modal<span>&#125;&#125;</span>
           </code>
         </pre>
     </div>

--- a/tests/unit/components/md-modal-container-test.js
+++ b/tests/unit/components/md-modal-container-test.js
@@ -1,0 +1,32 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('md-modal-container', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+
+test('it has the expected ID for md-modal to render into it', function(assert) {
+  assert.expect(1);
+
+  // Creates the component instance
+  var component = this.subject();
+  // Renders the component to the page
+  this.render();
+  assert.equal(component.$('#materialize-modal-root-element').length, 1, '#materialize-modal-root-element should be in the DOM');
+});


### PR DESCRIPTION
Fixes #81 

This PR adds a new component
```handlebars
{{md-modal-container}}
```
Which the user should add to their `application.hbs`. Modals are rendered as DOM children of this component (but their view hierarchy can really be anything, thanks to [ember-wormhole](https://github.com/yapplabs/ember-wormhole)).

Additionally, I have corrected some misleading documentation reported in #81 