### PR TITLE
Fixed possible XSS bug in md-loader style binding

### DIFF
--- a/addon/components/md-loader.js
+++ b/addon/components/md-loader.js
@@ -28,7 +28,8 @@ export default Ember.Component.extend({
   barStyle: computed('mode', 'percent', {
     get() {
       if (this.get('mode') === 'determinate') {
-        return `width: ${this.get('percent')}%`;
+        var percent = parseInt(this.get('percent'), 10);
+        return ("width: " + percent + '%').htmlSafe();
       }
       else {
         return null;


### PR DESCRIPTION
Got some Ember deprecation warnings in my console about a possible XSS bug. Found it was in `md-loader`, computed property `barStyle`.