### PR TITLE
Fixed floating button group example in docs

### DIFF
--- a/tests/dummy/app/templates/buttons.hbs
+++ b/tests/dummy/app/templates/buttons.hbs
@@ -41,10 +41,58 @@
   <div class="section">
     <h4 class="col s12 header">Floating</h4>
     <div class="button-example">
-      {{md-btn icon='mdi-action-favorite' action='debug' buttonType='floating'}}
+      {{md-btn icon='mdi-action-favorite' action='debug' buttonType='floating' class='btn-large'}}
       <pre class=" language-markup">
         <code class=" col s12 language-markup">
-          <span>&#123;&#123;</span>md-btn icon='mdi-action-favorite' action='debug' buttonType='floating'<span>&#125;&#125;</span>
+  <span>&#123;&#123;</span>md-btn icon='mdi-action-favorite' action='debug'
+           buttonType='floating' class="btn-large"<span>&#125;&#125;</span>
+        </code>
+      </pre>
+    </div>
+  </div>
+  <div class="section">
+    <h4 class="col s12 header">Floating Group</h4>
+    <div class="button-example">
+      <div class="fixed-action-btn" style="position: relative; display: inline-block; right: 0; bottom: 0">
+        {{md-btn icon='mdi-content-add' action='debug' buttonType='floating' class='btn-large lime darken-2'}}
+        <ul>
+          <li>{{md-btn icon='mdi-action-class' action='debug' buttonType='floating' class='indigo'}}</li>
+          <li>
+            {{md-btn icon='mdi-action-grade' action='debug' buttonType='floating' class='deep-purple'}}
+          </li>
+          <li>
+          {{md-btn icon='mdi-action-redeem' action='debug' buttonType='floating' class='green'}}
+          </li>
+          <li>
+          {{md-btn icon='mdi-alert-warning' action='debug' buttonType='floating' class='amber darken-3'}}
+          </li>
+        </ul>
+      </div>
+
+      <pre class=" language-markup">
+        <code class=" col s12 language-markup">
+  <span>&lt;</span>div class="fixed-action-btn"<span>&gt;</span>
+    <span>&#123;&#123;</span>md-btn icon='mdi-content-add' action='debug'
+           buttonType='floating' class='btn-large lime darken-2'<span>&#125;&#125;</span>
+    <span>&lt;</span>ul<span>&gt;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+        <span>&#123;&#123;</span>md-btn icon='mdi-action-class' action='debug'
+           buttonType='floating' class="indigo"<span>&#125;&#125;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+        <span>&#123;&#123;</span>md-btn icon='mdi-action-grade' action='debug'
+           buttonType='floating' class="deep-purple"<span>&#125;&#125;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+        <span>&#123;&#123;</span>md-btn icon='mdi-action-redeem' action='debug'
+           buttonType='floating' class="green"<span>&#125;&#125;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+        <span>&#123;&#123;</span>md-btn icon='mdi-action-warning' action='debug'
+           buttonType='floating' class="amber darken-3"<span>&#125;&#125;</span>
+      <span>&lt;</span>li<span>&gt;</span>
+    <span>&lt;</span>/ul<span>&gt;</span>
+  <span>&lt;</span>/div<span>&gt;</span>
         </code>
       </pre>
     </div>


### PR DESCRIPTION
![screen shot 2015-05-18 at 7 56 10 pm](https://cloud.githubusercontent.com/assets/558005/7694670/5c4e2a54-fd98-11e4-9aea-a1dec054c4b8.png)

Imo it's not necessary to build a new component for this, but it's nice to have an example in our docs

````handlebars
<div class="fixed-action-btn">
  {{md-btn icon='mdi-content-add' action='debug' buttonType='floating' class='btn-large lime darken-2'}}
  <ul>
    <li>{{md-btn icon='mdi-action-class' action='debug' buttonType='floating' class='indigo'}}</li>
    <li>
      {{md-btn icon='mdi-action-grade' action='debug' buttonType='floating' class='deep-purple'}}
    </li>
    <li>
    {{md-btn icon='mdi-action-redeem' action='debug' buttonType='floating' class='green'}}
    </li>
    <li>
    {{md-btn icon='mdi-alert-warning' action='debug' buttonType='floating' class='amber darken-3'}}
    </li>
  </ul>
</div>
````