### PR TITLE
[Enhancement] Floating button group

### DIFF
--- a/addon/components/-md-fixed-btn-base.js
+++ b/addon/components/-md-fixed-btn-base.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actionArgs: null,
+  large: true,
+
+  actions: {
+    fireButtonAction() {
+      var actionArgs = this.get('actionArgs');
+      if (actionArgs) {
+        this.sendAction('action', actionArgs || null);
+      }
+      else {
+        this.sendAction('action');
+      }
+    }
+  },
+
+  _btnClassString: Ember.computed('btnClass', function () {
+    return `${this.get('btnClass')} btn-floating ${this.get('large') ? 'btn-large' : ''}`;
+  })
+});

--- a/addon/components/md-fixed-btn.js
+++ b/addon/components/md-fixed-btn.js
@@ -1,0 +1,9 @@
+import FixedButtonBase from './-md-fixed-btn-base';
+import layout from '../templates/components/md-fixed-btn';
+
+export default FixedButtonBase.extend({
+  layout: layout,
+  tagName: 'li',
+  classNames: ['md-fixed-btn']
+
+});

--- a/addon/components/md-fixed-btns.js
+++ b/addon/components/md-fixed-btns.js
@@ -1,0 +1,9 @@
+import FixedButtonBase from './-md-fixed-btn-base';
+
+import layout from '../templates/components/md-fixed-btns';
+
+export default FixedButtonBase.extend({
+  layout: layout,
+  classNames: ['md-fixed-btns', 'fixed-action-btn']
+});
+

--- a/addon/templates/components/md-fixed-btn.hbs
+++ b/addon/templates/components/md-fixed-btn.hbs
@@ -1,0 +1,8 @@
+{{#md-btn
+  icon=btnIcon
+  class=_btnClassString
+  action='fireButtonAction'}}
+
+  {{yield}}
+
+{{/md-btn}}

--- a/addon/templates/components/md-fixed-btns.hbs
+++ b/addon/templates/components/md-fixed-btns.hbs
@@ -1,0 +1,8 @@
+{{md-btn
+  icon=btnIcon
+  class=_btnClassString
+  action='fireButtonAction'}}
+
+<ul>
+  {{yield}}
+</ul>

--- a/app/components/md-fixed-btn.js
+++ b/app/components/md-fixed-btn.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-materialize/components/md-fixed-btn';

--- a/app/components/md-fixed-btns.js
+++ b/app/components/md-fixed-btns.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-materialize/components/md-fixed-btns';

--- a/tests/dummy/app/controllers/buttons.js
+++ b/tests/dummy/app/controllers/buttons.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+
+  myData: Ember.A(["hello", "world"]),
+
+  actions: {
+    firstAction() {
+      window.alert('firstAction');
+    },
+    anotherAction(arg) {
+      window.alert(`anotherAction\narg: ${JSON.stringify(arg)}`);
+    }
+  }
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -90,3 +90,9 @@ a {
     }
   }
 }
+.fixed-btns-example {
+  position: relative;
+  display: inline-block;
+  right: 0;
+  bottom: 0;
+}

--- a/tests/dummy/app/templates/buttons.hbs
+++ b/tests/dummy/app/templates/buttons.hbs
@@ -53,46 +53,64 @@
   <div class="section">
     <h4 class="col s12 header">Floating Group</h4>
     <div class="button-example">
-      <div class="fixed-action-btn" style="position: relative; display: inline-block; right: 0; bottom: 0">
-        {{md-btn icon='mdi-content-add' action='debug' buttonType='floating' class='btn-large lime darken-2'}}
-        <ul>
-          <li>{{md-btn icon='mdi-action-class' action='debug' buttonType='floating' class='indigo'}}</li>
-          <li>
-            {{md-btn icon='mdi-action-grade' action='debug' buttonType='floating' class='deep-purple'}}
-          </li>
-          <li>
-          {{md-btn icon='mdi-action-redeem' action='debug' buttonType='floating' class='green'}}
-          </li>
-          <li>
-          {{md-btn icon='mdi-alert-warning' action='debug' buttonType='floating' class='amber darken-3'}}
-          </li>
-        </ul>
-      </div>
+      {{#md-fixed-btns
+        class="fixed-btns-example"
+        btnIcon="mdi-content-add"
+        btnClass="btn-large lime darken-2"
+        action="firstAction"
+        actionArgs="0"}}
+          {{md-fixed-btn
+            btnClass="indigo"
+            btnIcon="mdi-action-class"
+            action="anotherAction"
+            actionArgs="1"}}
+          {{md-fixed-btn
+            btnClass="deep-purple"
+            btnIcon="mdi-content-grade"
+            action="anotherAction"
+            actionArgs="abc"}}
+          {{md-fixed-btn
+            btnClass="green"
+            btnIcon="mdi-action-redeem"
+            action="anotherAction"
+            actionArgs=myData}}
+          {{md-fixed-btn
+            btnClass="green"
+            btnIcon="mdi-alert-warning"
+            action="anotherAction"}}
+      {{/md-fixed-btns}}
 
       <pre class=" language-markup">
         <code class=" col s12 language-markup">
-  <span>&lt;</span>div class="fixed-action-btn"<span>&gt;</span>
-    <span>&#123;&#123;</span>md-btn icon='mdi-content-add' action='debug'
-           buttonType='floating' class='btn-large lime darken-2'<span>&#125;&#125;</span>
-    <span>&lt;</span>ul<span>&gt;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-        <span>&#123;&#123;</span>md-btn icon='mdi-action-class' action='debug'
-           buttonType='floating' class="indigo"<span>&#125;&#125;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-        <span>&#123;&#123;</span>md-btn icon='mdi-action-grade' action='debug'
-           buttonType='floating' class="deep-purple"<span>&#125;&#125;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-        <span>&#123;&#123;</span>md-btn icon='mdi-action-redeem' action='debug'
-           buttonType='floating' class="green"<span>&#125;&#125;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-        <span>&#123;&#123;</span>md-btn icon='mdi-action-warning' action='debug'
-           buttonType='floating' class="amber darken-3"<span>&#125;&#125;</span>
-      <span>&lt;</span>li<span>&gt;</span>
-    <span>&lt;</span>/ul<span>&gt;</span>
-  <span>&lt;</span>/div<span>&gt;</span>
+<span>&#123;&#123;</span>#md-fixed-btns
+  btnIcon="mdi-content-add"
+  btnClass="btn-large lime darken-2"
+  action="firstAction"
+  actionArgs="0"<span>&#125;&#125;</span>
+
+    <span>&#123;&#123;</span>md-fixed-btn
+      btnClass="indigo"
+      btnIcon="mdi-action-class"
+      action="anotherAction"
+      actionArgs="1"<span>&#125;&#125;</span>
+
+    <span>&#123;&#123;</span>md-fixed-btn
+      btnClass="deep-purple"
+      btnIcon="mdi-content-grade"
+      action="anotherAction"
+      actionArgs="abc"<span>&#125;&#125;</span>
+
+    <span>&#123;&#123;</span>md-fixed-btn
+      btnClass="green"
+      btnIcon="mdi-action-redeem"
+      action="anotherAction"
+      actionArgs=myData<span>&#125;&#125;</span>
+
+    <span>&#123;&#123;</span>md-fixed-btn
+      btnClass="green"
+      btnIcon="mdi-alert-warning"
+      action="anotherAction"<span>&#125;&#125;</span>
+<span>&#123;&#123;</span>/md-fixed-btns<span>&#125;&#125;</span>
         </code>
       </pre>
     </div>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -51,7 +51,7 @@ module.exports = function(environment) {
   }
 
   ENV.contentSecurityPolicy = {
-    'default-src': "'none' 'unsafe-inline'",
+    'default-src': "'unsafe-inline'",
     'script-src': "'self' 'unsafe-eval' 'unsafe-inline'",
     'style-src': "'self' 'unsafe-inline'",
     'connect-src': "'self' ",

--- a/tests/integration/buttons-test.js
+++ b/tests/integration/buttons-test.js
@@ -5,6 +5,8 @@ import { module, test } from 'qunit';
 
 var App;
 
+var BUTTON_HOVER_TIMEOUT = 1000;
+
 module('Acceptance - Buttons', {
   setup: function() {
     App = startApp();
@@ -20,4 +22,65 @@ test('Load the demo page', function(assert) {
   andThen(function () {
     assert.ok(true, 'If this is passing, this page has no deprecation warnings');
   });
+});
+
+test('Floating buttons should be exposed on hover', assert => {
+  visit('/buttons');
+  var done = assert.async();
+
+  andThen(() => {
+    var mainButton = find('.fixed-btns-example > a.btn-floating');
+    assert.equal($('.fixed-btns-example ul li:first-child a').css('opacity'), "0", 'Secondary buttons should be hidden before mouseover');
+    Ember.$(mainButton).mouseover();
+  });
+
+  andThen(() => {
+    setTimeout(() => {
+      assert.equal($('.fixed-btns-example ul li:first-child a').css('opacity'), "1", 'Secondary buttons should be shown after mouseover');
+      done();
+    }, BUTTON_HOVER_TIMEOUT);
+  });
+});
+
+
+test('Clicking the first floating button should fire an action', assert => {
+  visit('/buttons');
+  var done = assert.async();
+
+  var oldAlert = window.alert;
+
+  window.alert = function (alertText) {
+    assert.equal(alertText, 'firstAction', 'firstAction is fired when primary button is clicked');
+    window.alert = oldAlert;
+    done();
+  };
+
+  click('.fixed-btns-example > a.btn-floating');
+
+});
+
+test('Clicking a secondary floating button should fire a different action, and pass arguments', assert => {
+  visit('/buttons');
+  var done = assert.async();
+
+  var oldAlert = window.alert;
+
+  andThen(() => {
+    var mainButton = find('.fixed-btns-example > a.btn-floating');
+    assert.equal($('.fixed-btns-example ul li:first-child a').css('opacity'), "0", 'Secondary buttons should be hidden before mouseover');
+    Ember.$(mainButton).mouseover();
+  });
+
+  andThen(() => {
+    setTimeout(() => {
+      window.alert = function (alertText) {
+        assert.equal(alertText, 'anotherAction\narg: "1"', 'firstAction is fired when primary button is clicked');
+        window.alert = oldAlert;
+        done();
+      };
+
+      click('.fixed-btns-example ul li:first-child a');
+    }, BUTTON_HOVER_TIMEOUT);
+  });
+
 });

--- a/tests/unit/components/md-fixed-btn-test.js
+++ b/tests/unit/components/md-fixed-btn-test.js
@@ -1,0 +1,59 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('md-fixed-btn', 'component:md-fixed-btn', {
+  // Specify the other units that are required for this test
+  needs: ['component:md-btn']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+
+test('btnIcon attribute results in an icon being rendered', function (assert) {
+  var component = this.subject({
+    btnIcon: 'mdi-content-add'
+  });
+
+  this.render();
+  assert.equal(component.$('i.mdi-content-add').length, 1, 'Icon should be present');
+});
+
+test('btnClass attribute should pass through to the button', function (assert) {
+  var component = this.subject({
+    btnClass: 'green'
+  });
+
+  this.render();
+  assert.equal(component.$('.btn-floating.green').length, 1, 'Class should be appended to button');
+});
+
+test('btn-floating and btn-large classes are on the button by default', function (assert) {
+  var component = this.subject();
+  this.render();
+  assert.equal(component.$('.btn-floating.btn-large').length, 1, 'Classes should be present');
+});
+
+test('button should be wrapped in a li tag', function (assert) {
+  var component = this.subject();
+  this.render();
+  assert.equal(Ember.$('li .btn-floating').length, 1, 'Button should be wrapped in a li tag');
+});
+
+test('Optionally, users can opt to use small floating buttons', function (assert) {
+  var component = this.subject({
+    large: false
+  });
+  this.render();
+  assert.equal(component.$('.btn-floating').length, 1, 'Button should be in DOM');
+  assert.equal(component.$('.btn-floating.btn-large').length, 0, 'Button should not be large');
+});

--- a/tests/unit/components/md-fixed-btns-test.js
+++ b/tests/unit/components/md-fixed-btns-test.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('md-fixed-btns', 'component:md-fixed-btns', {
+  // Specify the other units that are required for this test
+  needs: ['component:md-btn']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('btnIcon attribute results in an icon being rendered', function (assert) {
+  var component = this.subject({
+    btnIcon: 'mdi-content-add'
+  });
+
+  this.render();
+  assert.equal(component.$('i.mdi-content-add').length, 1, 'Icon should be present');
+});
+
+test('btnClass attribute should pass through to the button', function (assert) {
+  var component = this.subject({
+    btnClass: 'green'
+  });
+
+  this.render();
+  assert.equal(component.$('.btn-floating.green').length, 1, 'Class should be appended to button');
+});
+
+test('btn-floating and btn-large classes are on the button by default', function (assert) {
+  var component = this.subject();
+  this.render();
+  assert.equal(component.$('.btn-floating.btn-large').length, 1, 'Classes should be present');
+});
+
+test('Optionally, users can opt to use small floating buttons', function (assert) {
+  var component = this.subject({
+    large: false
+  });
+  this.render();
+  assert.equal(component.$('.btn-floating').length, 1, 'Button should be in DOM');
+  assert.equal(component.$('.btn-floating.btn-large').length, 0, 'Button should not be large');
+});
+
+test('there should be a UL tag to hold child buttons', function (assert) {
+  var component = this.subject();
+  this.render();
+  assert.equal(Ember.$('.fixed-action-btn ul').length, 1, 'ul should be present');
+});


### PR DESCRIPTION
After playing with this for a while, it feels like the semantics around fixed floating button groups get needlessly verbose, and are a good candidate for becoming an ember component

````hbs
{{#md-fixed-btns
  class="fixed-btns-example"
  btnIcon="mdi-content-add"
  btnClass="lime darken-2"
  action="firstAction"}}

    {{md-fixed-btn
      btnClass="indigo"
      btnIcon="mdi-action-class"
      action="anotherAction"}}

    {{md-fixed-btn
      btnClass="deep-purple"
      btnIcon="mdi-content-grade"
      action="otherAction"}}

    {{md-fixed-btn
      btnClass="green"
      btnIcon="mdi-action-redeem"
      action="someAction"}}

    {{md-fixed-btn
      btnClass="green"
      btnIcon="mdi-alert-warning"
      action="myAction"}}
{{/md-fixed-btns}}
````


![screen shot 2015-05-23 at 8 41 11 pm](https://cloud.githubusercontent.com/assets/558005/7786557/16817038-018c-11e5-93a9-47bf8a30a5d5.png)

#### TODO
- [x] Tests
- [x] Update documentation