### PR TITLE
make md-collapsible actionable

### DIFF
--- a/addon/components/md-collapsible.js
+++ b/addon/components/md-collapsible.js
@@ -5,5 +5,10 @@ export default Ember.Component.extend({
   layout: layout,
   tagName: 'li',
 
-  classNameBindings: ['class']
+  classNameBindings: ['class'],
+  actions: {
+    headerClicked() {
+      this.sendAction("action", this.get("model"));
+    }
+  }
 });

--- a/addon/components/md-collapsible.js
+++ b/addon/components/md-collapsible.js
@@ -4,7 +4,6 @@ import layout from '../templates/components/md-collapsible';
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'li',
-
   classNameBindings: ['class'],
   actions: {
     headerClicked() {

--- a/addon/templates/components/md-collapsible.hbs
+++ b/addon/templates/components/md-collapsible.hbs
@@ -1,4 +1,4 @@
-<div {{bind-attr class=":collapsible-header active:active:"}}>
+<div {{bind-attr class=":collapsible-header active:active:"}} {{action "headerClicked"}}>
     {{#if icon}}<i {{bind-attr class=icon}}></i>{{/if}}
     {{title}}
 </div>

--- a/tests/dummy/app/controllers/collapsible.js
+++ b/tests/dummy/app/controllers/collapsible.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    clicked(tabModel) {
+      if(tabModel === this.get("activeSlide")) {
+        this.set("activeSlide", null);
+      } else {
+        this.set("activeSlide", tabModel);
+      }
+    }
+  }
+});

--- a/tests/dummy/app/templates/collapsible.hbs
+++ b/tests/dummy/app/templates/collapsible.hbs
@@ -17,6 +17,8 @@
                 <li>icon, default value <span class="default-value badge">null</span></li>
                 <li>accordion, default value <span class="default-value badge">true</span></li>
                 <li>active, default value <span class="default-value badge">null</span></li>
+                <li>action, default value <span class="default-value badge">null</span></li>
+                <li>model, default value <span class="default-value badge">null</span></li>
             </ul>
         </div>
     </div>
@@ -132,6 +134,51 @@
                 laboris nisi ut aliquip ex ea commodo consequat.
             {{/md-collapsible}}
             {{#md-collapsible icon="mdi-social-whatshot" title="Three"}}
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                laboris nisi ut aliquip ex ea commodo consequat.
+            {{/md-collapsible}}
+          {{/md-card-collapsible}}
+
+            <pre class="language-markup">
+<code class=" col s12 language-markup">
+&#123;&#123;#md-card-collapsible&#125;&#125;
+  &#123;&#123;#md-collapsible icon="mdi-image-filter-drama" title="One"&#125;&#125;
+    Lorem ipsum dolor sit amet.
+  &#123;&#123;/md-collapsible&#125;&#125;
+  &#123;&#123;#md-collapsible icon="mdi-maps-place" title="Two" active=true&#125;&#125;
+    Lorem ipsum dolor sit amet.
+  &#123;&#123;/md-collapsible&#125;&#125;
+  &#123;&#123;#md-collapsible icon="mdi-social-whatshot" title="Three"&#125;&#125;
+    Lorem ipsum dolor sit amet.
+  &#123;&#123;/md-collapsible&#125;&#125;
+&#123;&#123;/md-card-collapsible&#125;&#125;
+</code>
+      </pre>
+        </div>
+    </div>
+
+    <div class="section">
+        <h4 class="col s12 header">Action Section</h4>
+        <div class="collapsible-example">
+
+          {{#md-card-collapsible id="preselected"}}
+            {{#md-collapsible icon="mdi-image-filter-drama" title="One" action="clicked" model="dog"}}
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+                minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                laboris nisi ut aliquip ex ea commodo consequat.
+            {{/md-collapsible}}
+            {{#md-collapsible icon="mdi-maps-place" title="Two" active=true action="clicked" model="cat"}}
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                laboris nisi ut aliquip ex ea commodo consequat.
+            {{/md-collapsible}}
+            {{#md-collapsible icon="mdi-social-whatshot" title="Three" action="clicked" model="bat"}}
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
                 labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
                 laboris nisi ut aliquip ex ea commodo consequat.

--- a/tests/dummy/app/templates/collapsible.hbs
+++ b/tests/dummy/app/templates/collapsible.hbs
@@ -162,40 +162,31 @@
         <h4 class="col s12 header">Action Section</h4>
         <div class="collapsible-example">
 
-          {{#md-card-collapsible id="preselected"}}
-            {{#md-collapsible icon="mdi-image-filter-drama" title="One" action="clicked" model="dog"}}
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-                minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
+          {{#md-card-collapsible id="action-selection"}}
+            {{#md-collapsible icon="mdi-image-filter-drama" title="Cloud" action="clicked" model="cloud"}}
+              O misty eye of the mountain below
             {{/md-collapsible}}
-            {{#md-collapsible icon="mdi-maps-place" title="Two" active=true action="clicked" model="cat"}}
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
+            {{#md-collapsible icon="mdi-maps-place" title="Marker" action="clicked" model="marker"}}
+              keep careful watch of my brothers' souls
             {{/md-collapsible}}
-            {{#md-collapsible icon="mdi-social-whatshot" title="Three" action="clicked" model="bat"}}
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
+            {{#md-collapsible icon="mdi-social-whatshot" title="Fire" action="clicked" model="fire"}}
+              and should the sky be filled with fire and smoke, keep watching over [indecipherable]
             {{/md-collapsible}}
           {{/md-card-collapsible}}
-
+          <h4>
+            active collapisble:<span id="selected-action">{{activeSlide}}</span>
+          </h4>
             <pre class="language-markup">
 <code class=" col s12 language-markup">
 &#123;&#123;#md-card-collapsible&#125;&#125;
-  &#123;&#123;#md-collapsible icon="mdi-image-filter-drama" title="One"&#125;&#125;
-    Lorem ipsum dolor sit amet.
+  &#123;&#123;#md-collapsible icon="mdi-image-filter-drama" title="One" action="clicked" model="cloud"&#125;&#125;
+    O misty eye of the mountain below
   &#123;&#123;/md-collapsible&#125;&#125;
-  &#123;&#123;#md-collapsible icon="mdi-maps-place" title="Two" active=true&#125;&#125;
-    Lorem ipsum dolor sit amet.
+  &#123;&#123;#md-collapsible icon="mdi-maps-place" title="Two" action="clicked" model="marker"&#125;&#125;
+    keep careful watch of my brothers' souls
   &#123;&#123;/md-collapsible&#125;&#125;
-  &#123;&#123;#md-collapsible icon="mdi-social-whatshot" title="Three"&#125;&#125;
-    Lorem ipsum dolor sit amet.
+  &#123;&#123;#md-collapsible icon="mdi-social-whatshot" title="Three" action="clicked" model="fire"&#125;&#125;
+    and should the sky be filled with fire and smoke, keep watching over [indecipherable]
   &#123;&#123;/md-collapsible&#125;&#125;
 &#123;&#123;/md-card-collapsible&#125;&#125;
 </code>

--- a/tests/integration/collapsible-test.js
+++ b/tests/integration/collapsible-test.js
@@ -8,6 +8,7 @@ var App;
 module('Acceptance - Collapsible', {
   setup: function() {
     App = startApp();
+    visit('/collapsible');
   },
   teardown: function() {
     Ember.run(App, 'destroy');
@@ -15,7 +16,6 @@ module('Acceptance - Collapsible', {
 });
 
 test('Collapsible basic tests', function(assert) {
-  visit('/collapsible');
 
   andThen(function() {
     assert.equal(find('#accordion>li').length, 3, 'Accordion should have 3 headers');
@@ -24,5 +24,26 @@ test('Collapsible basic tests', function(assert) {
     assert.equal(find('#accordion>li>.active').length, 0, 'Accordion should not have an active collapsible');
     assert.equal(find('#expandable>li>.active').length, 0, 'Expandable should not have an active collapsible');
     assert.equal(find('#preselected>li>.active').length, 1, 'Preselected should have an active collapsible');
+    assert.equal(find('#action-selection>li').length, 3, 'Action selection should also have 3 headers');
   });
+  
+});
+
+test('Action collapsible operations', function(assert){
+  andThen(function(){
+    assert.equal(find("#selected-action").text(), "", "there should be no selected action");
+  });
+
+  click('#action-selection>li:first-child>.collapsible-header');
+  
+  andThen(function(){
+    assert.equal(find("#selected-action").text(), "cloud", "after clicking, we should have the correct selected action");
+    assert.equal(find('#action-selection>li>.active').length, 1, "we should have an activated tab");
+  });
+
+  click('#action-selection>li:nth-child(2)>.collapsible-header');
+
+  andThen(function(){
+    assert.equal(find("#selected-action").text(), "marker", "clicking another header should fire the action again");
+  });  
 });


### PR DESCRIPTION
As per this issue:
https://github.com/sgasser/ember-cli-materialize/issues/112

now, md-collapsible can be made to split out an action when a user interacts with it:

```handlebars
{{#md-card-collapsible id="action-selection"}}
  {{#md-collapsible icon="mdi-image-filter-drama" title="Cloud" action="clicked" model="cloud"}}
    O misty eye of the mountain below
  {{/md-collapsible}}
  {{#md-collapsible icon="mdi-maps-place" title="Marker" action="clicked" model="marker"}}
    keep careful watch of my brothers' souls
  {{/md-collapsible}}
  {{#md-collapsible icon="mdi-social-whatshot" title="Fire" action="clicked" model="fire"}}
    and should the sky be filled with fire and smoke, keep watching over [indecipherable]
  {{/md-collapsible}}
{{/md-card-collapsible}}
```
If provided with action, it is now possible to handle this in your controller (or wherever):
```javascript
export default Ember.Controller.extend({
  actions: {
    clicked(tabModel) {
      if(tabModel === this.get("activeSlide")) {
        this.set("activeSlide", null);
      } else {
        this.set("activeSlide", tabModel);
      }
    }
  }
});
```
If you passed in a model to the md-collapsible, it will be given to you as your first argument in your action handler. This way, you have some idea what model your user is trying to interact with.