### PR TITLE
Ember 1.13 workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An [ember-cli](http://www.ember-cli.com) addon for using [Materialize](http://materializecss.com/) (CSS Framework based on [Material Design](http://www.google.com/design/spec/material-design/introduction.html)) in Ember applications.
 
-*Materialize Version ~0.96.1
+*Materialize Version ~0.97.0
 
 ## Main features
 

--- a/addon/components/md-navbar.js
+++ b/addon/components/md-navbar.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/md-navbar';
+import computed from 'ember-new-computed';
 
 export default Ember.Component.extend({
   tagName: 'nav',
@@ -13,11 +14,18 @@ export default Ember.Component.extend({
 
   _setupNavbar() {
     if(Ember.typeOf(Ember.$('.button-collapse').sideNav) === 'function'){
+      this.notifyPropertyChange('_sideNavId');
       this.$('.button-collapse').sideNav({
         closeOnClick: true
       });
     }
-  }
+  },
+
+  _sideNavId: computed({
+    get() {
+      return `${this.get('element.id')}-sidenav`;
+    }
+  })
 
   //TODO: Unregister any listeners that $.sideNav() puts in place
   // _teardownNavbar() {

--- a/addon/components/md-tab.js
+++ b/addon/components/md-tab.js
@@ -13,6 +13,7 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
+    this.notifyPropertyChange('_tabSet');
     this._registerTab();
   },
 
@@ -28,6 +29,9 @@ export default Ember.Component.extend({
 
   _tabSet: computed({
     get() {
+      if (this.get('_state') === 'preRender') {
+        return null;
+      }
       return this.nearestWithProperty('___materializeTabs');
     }
   }),
@@ -40,9 +44,23 @@ export default Ember.Component.extend({
 
   _registerTab() {
     var tabSet = this.get('_tabSet');
+    /**
+      This is a hack for a case where nearestWithProperty doesn't
+      work properly in Ember 1.13. Will remove in a future version
+      as the glimmer composability story improves
+    */
+
     if (!tabSet) {
-      throw new Error('materialize-tabs-tab cannot be used outside the context of a materialize-tabs');
+      var backupTabSet = this.$().closest('.materialize-tabs')[0];
+      if (backupTabSet) {
+        tabSet = this.get('_viewRegistry')[backupTabSet.id];
+      }
     }
-    tabSet.registerTab(this);
+    if (this.get('_state') !== 'preRender') {
+      if (tabSet === undefined) {
+        throw new Error('materialize-tabs-tab cannot be used outside the context of a materialize-tabs');
+      }
+      tabSet.registerTab(this);
+    }
   }
 });

--- a/addon/components/md-tabs.js
+++ b/addon/components/md-tabs.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend({
   classNames: ['materialize-tabs', 'row'],
 
   content: null,
-  ___materializeTabs: true,
+  ___materializeTabs: 'yes',
   _tabComponents: null,
   numTabs: Ember.computed.alias('_tabComponents.length'),
   selected: null,

--- a/addon/templates/components/md-navbar.hbs
+++ b/addon/templates/components/md-navbar.hbs
@@ -4,11 +4,13 @@
     <ul class='right hide-on-med-and-down'>
       {{yield}}
     </ul>
-    <ul id='nav-mobile' class='side-nav'>
-      {{yield}}
-    </ul>
+
   </div>
-  {{#link-to 'index' class='button-collapse' data-activates='nav-mobile'}}
+  <a class='button-collapse' {{bind-attr data-activates=_sideNavId}}>
+
     <i class='mdi-navigation-menu'></i>
-  {{/link-to}}
+  </a>
 </div>
+<ul {{bind-attr id=_sideNavId}} class='side-nav'>
+  {{yield}}
+</ul>

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "materialize": "~0.96.1",
+    "materialize": "~0.97.0",
     "qunit": "~1.17.1"
   },
   "resolutions": {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -5,7 +5,7 @@ $button-color: #e51c23;
 
 
 .index-banner {
-  background-color: color('grey', 'lighten-2');
+  background-color: color('grey', 'lighten-3');
   .container {
     position: relative;
     .header {
@@ -13,10 +13,10 @@ $button-color: #e51c23;
     }
   }
   h4 {
-  margin-bottom: 40px;
+    margin-bottom: 40px;
   }
   a{
-    color: #fff;
+    color: color('deep-orange', 'base');
   }
 }
 
@@ -49,12 +49,12 @@ a {
   font-size: 1.2em;
 }
 
-/* FIXME: Workaround for https://github.com/Dogfalo/materialize/issues/1079 */
-@each $mdi-icon-name, $mdi-icon-value in $mdi-list-icons {
-  .#{$mdi-prefix}#{$mdi-icon-name}:before {
-    content: "\""+ $mdi-icon-value +"\"";
-  }
-}
+// /* FIXME: Workaround for https://github.com/Dogfalo/materialize/issues/1079 */
+// @each $mdi-icon-name, $mdi-icon-value in $mdi-list-icons {
+//   .#{$mdi-prefix}#{$mdi-icon-name}:before {
+//     content: "\""+ $mdi-icon-value +"\"";
+//   }
+// }
 
 // Qunit test runner style fixes
 #qunit-testrunner-toolbar {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -6,7 +6,7 @@
           <img class="ember-logo hide-on-med-and-down" src="images/ember-white.svg" />
           Materialize
         </a>
-        <a href="#" data-activates="mobile-demo" class="button-collapse deep-orange-text text-darken-2"><i class="mdi-navigation-menu"></i></a>
+        <a href="#" data-activates="mobile-demo" class="button-collapse demo-button-collapse deep-orange-text text-darken-2"><i class="mdi-navigation-menu"></i></a>
       </div>
     </div>
   </nav>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -11,19 +11,20 @@
     </div>
   </nav>
 </div>
- <ul class="side-nav fixed demo-page-submenu" id="mobile-demo">
-    {{#each demoSections as |section|}}
-        {{#link-to section.route activeClass='active' tagName='li'}}
-          {{link-to section.name section.route class="deep-orange-text text-darken-2"}}
-        {{/link-to}}
-    {{/each}}
-  </ul>
+<ul class="side-nav fixed demo-page-submenu" id="mobile-demo">
+  {{#each demoSections as |section|}}
+    {{#link-to section.route activeClass='active' tagName='li'}}
+      {{link-to section.name section.route class="deep-orange-text text-darken-2"}}
+    {{/link-to}}
+  {{/each}}
+</ul>
+
 <main>
   {{outlet}}
 </main>
+
 {{md-modal-container}}
 
 <footer class="page-footer deep-orange darken-2">
-
   {{#md-copyright text='Copyright Text' startYear=2014}}<a class="grey-text text-lighten-4 right" href="#!">More Links</a>{{/md-copyright}}
 </footer>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col s12 m9">
         <h1 class="header"><a href="http://materializecss.com/" target="_blank">Materialize.css</a></h1>
-        <h4 class="light deep-orange-text text-lighten-4">A CSS Framework based on <a href="http://www.google.com/design/spec/material-design/introduction.html" target="_blank">Material Design</a> made simple, for Ember.js apps.</h4>
+        <h4 class="light deep-orange-text text-lighten-3">A CSS Framework based on <a href="http://www.google.com/design/spec/material-design/introduction.html" target="_blank">Material Design</a> made simple, for Ember.js apps.</h4>
       </div>
     </div>
   </div>
@@ -11,7 +11,8 @@
 <div class="github-commit">
   <div class="container">
     <div class="commit">
-      <a id="github-button" href="https://github.com/sgasser/ember-cli-materialize" class="btn right grey deep-orange-text lighten-2 text-darken-2 waves-effect waves-light hide-on-med-and-down">Github</a>
+      <a id="github-button" href="https://github.com/sgasser/ember-cli-materialize" class="btn right grey deep-orange-text lighten-2 text-darken-2 waves-effect waves-light hide-on-med-and-down">
+      Github</a>
     </div>
   </div>
 </div>

--- a/tests/dummy/app/views/application.js
+++ b/tests/dummy/app/views/application.js
@@ -3,6 +3,6 @@ export default Ember.View.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    this.$('nav .button-collapse').sideNav();
+    this.$('.demo-button-collapse').sideNav();
   }
 });


### PR DESCRIPTION
this.nearestWithProperty still is not working in a certain scenario with tabs, but I have found a workaround by using the view registry. In a future version, I'll remove this hack, but better to get all tests passing in the current release sooner and find a proper fix (or apply a framework fix) later.